### PR TITLE
Remove email and GitHub contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,6 @@
             
             <div class="contact-links" role="list" aria-label="Contact methods">
                 <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener noreferrer" class="contact-link" role="listitem">LinkedIn Profile</a>
-                <a href="mailto:contact@hugomonteiro.com" class="contact-link" role="listitem">Email</a>
-                <a href="https://github.com/HFMonteiro" target="_blank" rel="noopener noreferrer" class="contact-link" role="listitem">GitHub</a>
             </div>
             
             <p class="contact-note">This website serves as a digital portfolio and is continuously updated to reflect current projects and professional developments.</p>

--- a/script.js
+++ b/script.js
@@ -198,12 +198,8 @@
         // Enhance contact links with better accessibility
         const contactLinks = document.querySelectorAll('.contact-link');
         contactLinks.forEach(link => {
-            if (link.getAttribute('href').startsWith('mailto:')) {
-                link.setAttribute('aria-label', `Send email to ${link.textContent}`);
-            } else if (link.getAttribute('href').includes('linkedin')) {
+            if (link.getAttribute('href').includes('linkedin')) {
                 link.setAttribute('aria-label', `Visit Hugo Monteiro's LinkedIn profile (opens in new tab)`);
-            } else if (link.getAttribute('href').includes('github')) {
-                link.setAttribute('aria-label', `Visit Hugo Monteiro's GitHub profile (opens in new tab)`);
             }
         });
     }


### PR DESCRIPTION
## Summary
- Remove email and GitHub contact links from contact section
- Simplify accessibility script to handle only LinkedIn link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33feb9f588328bbdb13534b0838a6