### PR TITLE
Remove raw.githack references from docs and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to raw.githack.com
+name: Deploy Validation
 
 on:
   push:
@@ -67,38 +67,6 @@ jobs:
           echo "Warning: styles.css not found"
         fi
         
-    - name: Comment PR with raw.githack URL
-      if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const username = context.repo.owner;
-          const repo = context.repo.repo;
-          const prNumber = context.issue.number;
-          const branch = context.payload.pull_request.head.ref;
-          
-          const rawGithackUrl = `https://raw.githack.com/${username}/${repo}/${branch}/index.html`;
-          
-          const comment = `🚀 **Preview your changes:**
-          
-          **Raw.githack URL:** [${rawGithackUrl}](${rawGithackUrl})
-          
-          This URL allows you to preview your static website without activating GitHub Pages.
-          
-          To customize this template:
-          1. Replace \`<USERNAME>\` with \`${username}\`
-          2. Replace \`<REPO>\` with \`${repo}\`
-          
-          The final URL template: \`https://raw.githack.com/<USERNAME>/<REPO>/main/index.html\``;
-          
-          github.rest.issues.createComment({
-            issue_number: prNumber,
-            owner: username,
-            repo: repo,
-            body: comment
-          });
-          
     - name: Output deployment info
       run: |
         echo "🎉 Deployment validation complete!"
@@ -108,7 +76,3 @@ jobs:
         if [ -f "styles.css" ]; then echo "  ✅ styles.css found"; fi
         if [ -f "script.js" ]; then echo "  ✅ script.js found"; fi
         echo ""
-        echo "🌐 Raw.githack URLs:"
-        echo "  Main branch: https://raw.githack.com/<USERNAME>/<REPO>/main/index.html"
-        echo ""
-        echo "Replace <USERNAME> and <REPO> with your actual GitHub username and repository name."

--- a/README.md
+++ b/README.md
@@ -71,18 +71,8 @@ Publications are automatically updated weekly from ORCID profile `0000-0002-6060
 ## 🌐 Deployment
 
 **Primary:** GitHub Pages or any static hosting service  
-**Development:** raw.githack.com for immediate preview
-
-### Raw.githack URLs (Development):
-- **English:** `https://raw.githack.com/HFMonteiro/Webpage/v0.1/en/index.html`
-- **Portuguese:** `https://raw.githack.com/HFMonteiro/Webpage/v0.1/pt/index.html`
 
 ## 🔄 GitHub Actions
-
-**Deployment Validation** (`.github/workflows/deploy.yml`):
-- Triggers on push and pull requests
-- Validates HTML structure and basic integrity
-- Provides raw.githack preview URLs in PR comments
 
 **ORCID Publications** (`.github/workflows/fetch_orcid.yml`):
 - Weekly automatic updates every Monday at 06:00 UTC


### PR DESCRIPTION
## Summary
- drop raw.githack preview section from README and restructure GitHub Actions description
- remove raw.githack URL generation from deploy workflow and give it a generic name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d5d1c948328b9c2f6bad0eaf276