### PR TITLE
Remove email contact option and adjust layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -923,7 +923,10 @@ footer p {
         grid-template-columns: repeat(2, 1fr);
     }
     
-    .contact-grid,
+    .contact-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
     .opportunities-grid {
         grid-template-columns: repeat(3, 1fr);
     }

--- a/en/contact.html
+++ b/en/contact.html
@@ -100,18 +100,6 @@
                         </a>
                     </div>
 
-                    <div class="contact-item">
-                        <h4>Email Contact</h4>
-                        <p>For direct communication about professional opportunities and collaborations.</p>
-                        <a href="mailto:hugo.monteiro@example.com" class="contact-link email">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M4 4H20C21.1 4 22 4.9 22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6C2 4.9 2.9 4 4 4Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                <polyline points="22,6 12,13 2,6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                            </svg>
-                            Professional Email
-                        </a>
-                        <p class="note">*Please use LinkedIn for initial contact as it's monitored more frequently</p>
-                    </div>
                 </div>
             </section>
 

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -100,18 +100,6 @@
                         </a>
                     </div>
 
-                    <div class="contact-item">
-                        <h4>Contacto por Email</h4>
-                        <p>Para comunicação direta sobre oportunidades profissionais e colaborações.</p>
-                        <a href="mailto:hugo.monteiro@example.com" class="contact-link email">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M4 4H20C21.1 4 22 4.9 22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6C2 4.9 2.9 4 4 4Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                <polyline points="22,6 12,13 2,6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                            </svg>
-                            Email Profissional
-                        </a>
-                        <p class="note">*Por favor use o LinkedIn para contacto inicial pois é monitorizado com mais frequência</p>
-                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- remove email contact item from English and Portuguese contact pages
- ensure contact grid uses two columns so remaining items align correctly

## Testing
- `tidy -e -q en/contact.html`
- `tidy -e -q pt/contacto.html`
- `python -m py_compile scripts/fetch_orcid.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac2d6c55c08328a595de1d7bf6a6a6