### PR TITLE
Remove obsolete CV download sections from contact pages

### DIFF
--- a/en/contact.html
+++ b/en/contact.html
@@ -186,11 +186,6 @@
                 </div>
             </section>
 
-            <section class="download-cv">
-                <h3>Professional Documentation</h3>
-                <p>For detailed information about my background, qualifications, and experience:</p>
-                <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Download Complete CV</a>
-            </section>
         </article>
     </main>
 

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -186,11 +186,6 @@
                 </div>
             </section>
 
-            <section class="download-cv">
-                <h3>Documentação Profissional</h3>
-                <p>Para informação detalhada sobre o meu background, qualificações e experiência:</p>
-                <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Descarregar CV Completo</a>
-            </section>
         </article>
     </main>
 


### PR DESCRIPTION
## Summary
- Remove Download CV section from English and Portuguese contact pages
- Ensure footer sits directly beneath response expectations section

## Testing
- `tidy -q -e en/contact.html`
- `tidy -q -e pt/contacto.html`


------
https://chatgpt.com/codex/tasks/task_e_68ac2d6efafc8328871455903e20e65a