### PR TITLE
Remove ORCID contact block

### DIFF
--- a/en/contact.html
+++ b/en/contact.html
@@ -91,15 +91,6 @@
                         </a>
                     </div>
 
-                    <div class="contact-item">
-                        <h4>Research Profile</h4>
-                        <p>View my research publications and academic contributions on ORCID.</p>
-                        <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener noreferrer" class="contact-link orcid">
-                            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="24" height="24">
-                            ORCID Profile
-                        </a>
-                    </div>
-
                 </div>
             </section>
 

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -91,15 +91,6 @@
                         </a>
                     </div>
 
-                    <div class="contact-item">
-                        <h4>Perfil de Investigação</h4>
-                        <p>Veja as minhas publicações de investigação e contribuições académicas no ORCID.</p>
-                        <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener noreferrer" class="contact-link orcid">
-                            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="24" height="24">
-                            Perfil ORCID
-                        </a>
-                    </div>
-
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- drop ORCID contact item from English and Portuguese contact pages
- keep single LinkedIn contact method

## Testing
- `html5validator --root . --files en/contact.html pt/contacto.html` *(fails: Bad value "X-Content-Type-Options" for attribute "http-equiv"...)*
- `python - <<'PY' ...` (footer anchor link check)


------
https://chatgpt.com/codex/tasks/task_e_68ac31f4463c8328b73ec03895ec0a42