### PR TITLE
Remove CV download references and PDF file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A bilingual (EN/PT) professional website for Hugo Monteiro, MD/MPH, PhD candidat
 - **ORCID Integration**: Automatic weekly updates of publications from ORCID profile
 - **Bilingual Content**: Complete page translations for all sections
 - **Professional Sections**: About, Research, Experience, Publications, Contact
-- **CV Download**: Integrated curriculum vitae access
 
 ### Technical Excellence
 - **SEO Optimized**: Complete metadata, sitemap.xml, robots.txt, JSON-LD structured data
@@ -45,8 +44,6 @@ A bilingual (EN/PT) professional website for Hugo Monteiro, MD/MPH, PhD candidat
 │   ├── css/styles.css           # Main stylesheet
 │   ├── js/script.js             # Enhanced JavaScript
 │   └── img/                     # Images, favicons
-├── docs/                        # Documents
-│   └── Hugo_Monteiro_CV.pdf     # Curriculum Vitae
 ├── publications/                # Auto-generated content
 │   ├── publications_en.md       # English publications
 │   └── publications_pt.md       # Portuguese publications

--- a/docs/Hugo_Monteiro_CV.pdf
+++ b/docs/Hugo_Monteiro_CV.pdf
@@ -1,7 +1,0 @@
-# CV Placeholder
-
-This is a placeholder for Hugo_Monteiro_CV.pdf
-
-The actual CV file should be uploaded to this location: /docs/Hugo_Monteiro_CV.pdf
-
-This placeholder file is for development and testing purposes only.

--- a/en/about.html
+++ b/en/about.html
@@ -196,7 +196,7 @@
                 <h3>Let's Connect</h3>
                 <p>I'm always interested in collaborating on digital health initiatives and sharing knowledge with fellow healthcare professionals and technology innovators.</p>
                 <div class="cta-actions">
-                    <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Download CV</a>
+                    <!-- CV link removed -->
                     <a href="/en/contact.html" class="btn btn-secondary">Get in Touch</a>
                 </div>
             </section>

--- a/en/experience.html
+++ b/en/experience.html
@@ -217,7 +217,7 @@
                 <h3>Professional Collaboration</h3>
                 <p>I'm interested in collaborating on digital health initiatives, public health research, and health system optimization projects.</p>
                 <div class="cta-actions">
-                    <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Download CV</a>
+                    <!-- CV link removed -->
                     <a href="/en/contact.html" class="btn btn-secondary">Connect</a>
                 </div>
             </section>

--- a/en/index.html
+++ b/en/index.html
@@ -118,7 +118,7 @@
             <p class="hero-text">Portuguese MD/MPH dedicated to digital health transformation and improving healthcare delivery through innovative technology solutions.</p>
             
             <div class="hero-actions">
-                <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Download CV</a>
+                <!-- CV link removed -->
                 <a href="/en/about.html" class="btn btn-secondary">Learn More</a>
             </div>
             

--- a/en/publications.html
+++ b/en/publications.html
@@ -107,11 +107,7 @@
                         <a href="/en/contact.html" class="resource-link">Get in Touch</a>
                     </div>
                     
-                    <div class="resource-item">
-                        <h4>CV Download</h4>
-                        <p>Download my complete curriculum vitae with all credentials.</p>
-                        <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="resource-link">Download CV</a>
-                    </div>
+                    <!-- CV download link removed -->
                 </div>
             </section>
         </article>

--- a/pt/experiencia.html
+++ b/pt/experiencia.html
@@ -192,7 +192,7 @@
                 <h3>Colaboração Profissional</h3>
                 <p>Estou interessado em colaborar em iniciativas de saúde digital, investigação em saúde pública e projetos de otimização de sistemas de saúde.</p>
                 <div class="cta-actions">
-                    <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Descarregar CV</a>
+                    <!-- Link de CV removido -->
                     <a href="/pt/contacto.html" class="btn btn-secondary">Conectar</a>
                 </div>
             </section>

--- a/pt/index.html
+++ b/pt/index.html
@@ -118,7 +118,7 @@
             <p class="hero-text">Médico português com MPH dedicado à transformação digital da saúde e ao melhoramento da prestação de cuidados através de soluções tecnológicas inovadoras.</p>
             
             <div class="hero-actions">
-                <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Descarregar CV</a>
+                <!-- Link de CV removido -->
                 <a href="/pt/sobre.html" class="btn btn-secondary">Saber Mais</a>
             </div>
             

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -107,11 +107,7 @@
                         <a href="/pt/contacto.html" class="resource-link">Entrar em Contacto</a>
                     </div>
                     
-                    <div class="resource-item">
-                        <h4>Descarregar CV</h4>
-                        <p>Descarregue o meu curriculum vitae completo com todas as credenciais.</p>
-                        <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="resource-link">Descarregar CV</a>
-                    </div>
+                    <!-- Link de descarregamento de CV removido -->
                 </div>
             </section>
         </article>

--- a/pt/sobre.html
+++ b/pt/sobre.html
@@ -196,7 +196,7 @@
                 <h3>Vamos Conectar</h3>
                 <p>Estou sempre interessado em colaborar em iniciativas de saúde digital e partilhar conhecimento com colegas profissionais de saúde e inovadores tecnológicos.</p>
                 <div class="cta-actions">
-                    <a href="/docs/Hugo_Monteiro_CV.pdf" target="_blank" rel="noopener" class="btn btn-primary">Descarregar CV</a>
+                    <!-- Link de CV removido -->
                     <a href="/pt/contacto.html" class="btn btn-secondary">Entrar em Contacto</a>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- remove CV download link blocks from English and Portuguese pages
- drop CV references from README and delete the outdated PDF

## Testing
- `python -m py_compile scripts/fetch_orcid.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac31f76bc08328a38d922b0a0b622e