### PR TITLE
Remove redundant Allow directive from robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,4 @@
 User-agent: *
-Allow: /
-
 # Sitemap
 Sitemap: https://hfmonteiro.com/sitemap.xml
 
@@ -11,4 +9,3 @@ Disallow: /*.log
 
 # Crawl-delay for polite crawling
 Crawl-delay: 1
-


### PR DESCRIPTION
## Summary
- simplify robots rules by dropping redundant `Allow: /`
- ensure file ends with a newline and contains no trailing spaces

## Testing
- `rg '[ \t]+$' -n robots.txt`
- `od -An -t o1 -c robots.txt | tail -n 1`
- `python3 -m py_compile scripts/fetch_orcid.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac31fa9c4c83289bceb9403e6d99f3