### PR TITLE
Hide decorative icons from screen readers

### DIFF
--- a/en/contact.html
+++ b/en/contact.html
@@ -86,7 +86,7 @@
                         <h4>Professional Network</h4>
                         <p>Connect with me on LinkedIn for professional discussions and collaboration opportunities.</p>
                         <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener noreferrer" class="contact-link linkedin">
-                            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original.svg" alt="LinkedIn" width="24" height="24">
+                            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original.svg" alt="" aria-hidden="true" focusable="false" width="24" height="24">
                             LinkedIn Profile
                         </a>
                     </div>
@@ -95,7 +95,7 @@
                         <h4>Research Profile</h4>
                         <p>View my research publications and academic contributions on ORCID.</p>
                         <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener noreferrer" class="contact-link orcid">
-                            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="24" height="24">
+                            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="" aria-hidden="true" focusable="false" width="24" height="24">
                             ORCID Profile
                         </a>
                     </div>

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -86,7 +86,7 @@
                         <h4>Rede Profissional</h4>
                         <p>Conecte comigo no LinkedIn para discussões profissionais e oportunidades de colaboração.</p>
                         <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener noreferrer" class="contact-link linkedin">
-                            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original.svg" alt="LinkedIn" width="24" height="24">
+                            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original.svg" alt="" aria-hidden="true" focusable="false" width="24" height="24">
                             Perfil LinkedIn
                         </a>
                     </div>
@@ -95,7 +95,7 @@
                         <h4>Perfil de Investigação</h4>
                         <p>Veja as minhas publicações de investigação e contribuições académicas no ORCID.</p>
                         <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener noreferrer" class="contact-link orcid">
-                            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="24" height="24">
+                            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="" aria-hidden="true" focusable="false" width="24" height="24">
                             Perfil ORCID
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- mark decorative LinkedIn and ORCID icons as aria-hidden and non-focusable in English and Portuguese contact pages
- ensure link text remains the accessible name

## Testing
- `python -m py_compile scripts/fetch_orcid.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac321ad75c8328842225272557c27c