### PR TITLE
Remove keywords meta tags from Portuguese HTML pages

### DIFF
--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -7,7 +7,6 @@
     <!-- SEO Meta Tags -->
     <title>Contacto - Hugo Monteiro | Entre em Contacto para Colaboração em Saúde Digital</title>
     <meta name="description" content="Contacte Hugo Monteiro para colaboração em saúde digital, parcerias de investigação, consultorias ou palestras. Conecte via LinkedIn ou ORCID.">
-    <meta name="keywords" content="Hugo Monteiro contacto, colaboração saúde digital, consultoria saúde pública, parcerias investigação, contacto consultor OMS">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->

--- a/pt/experiencia.html
+++ b/pt/experiencia.html
@@ -7,7 +7,6 @@
     <!-- SEO Meta Tags -->
     <title>Experiência - Hugo Monteiro | Experiência Profissional em Saúde & Saúde Digital</title>
     <meta name="description" content="Explore a experiência profissional de Hugo Monteiro como Médico de Saúde Pública, Coordenador de Programas, Consultor OMS/Europa e Industry Fellow em transformação de saúde digital.">
-    <meta name="keywords" content="Hugo Monteiro experiência, médico saúde pública, consultor OMS, especialista saúde digital, coordenador SNS, industry fellow">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->

--- a/pt/index.html
+++ b/pt/index.html
@@ -7,7 +7,6 @@
     <!-- SEO Meta Tags -->
     <title>Hugo Monteiro - MD/MPH | Especialista em Saúde Digital</title>
     <meta name="description" content="Hugo Monteiro é um médico português com MPH dedicado à transformação digital da saúde e ao melhoramento da prestação de cuidados através de soluções tecnológicas inovadoras.">
-    <meta name="keywords" content="saúde digital, tecnologia em saúde, saúde pública, médico, transformação da saúde, médico português">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -7,7 +7,6 @@
     <!-- SEO Meta Tags -->
     <title>Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública</title>
     <meta name="description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
-    <meta name="keywords" content="investigação saúde digital, sistemas informação saúde, programas rastreio, visualização dados saúde, investigação saúde pública">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -7,7 +7,6 @@
     <!-- SEO Meta Tags -->
     <title>Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital</title>
     <meta name="description" content="Explore as publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas automaticamente do ORCID.">
-    <meta name="keywords" content="Hugo Monteiro publicações, investigação saúde digital, investigação saúde pública, artigos ciência dados saúde, publicações ORCID">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->

--- a/pt/sobre.html
+++ b/pt/sobre.html
@@ -7,7 +7,6 @@
     <!-- SEO Meta Tags -->
     <title>Sobre - Hugo Monteiro | MD/MPH Especialista em Saúde Digital</title>
     <meta name="description" content="Conheça Hugo Monteiro, médico português com MPH e doutorando em Ciência de Dados em Saúde, dedicado à transformação digital da saúde na política e operações dos cuidados de saúde.">
-    <meta name="keywords" content="Hugo Monteiro, MD MPH, saúde digital, médico saúde pública, ciência dados saúde, consultor OMS">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -212,5 +211,4 @@
     <script src="/assets/js/script.js" defer></script>
 </body>
 </html>
-
 


### PR DESCRIPTION
### Motivation
- Remove deprecated `<meta name="keywords">` tags from the Portuguese site to align with modern SEO best practices and reduce redundant metadata.
- Preserve clear SEO intent on each page by keeping strong `<title>` and `<meta name="description">` entries so search engines still receive explicit page summaries.

### Description
- Deleted the `<meta name="keywords">` lines from `pt/index.html`, `pt/sobre.html`, `pt/experiencia.html`, `pt/investigacao.html`, `pt/publicacoes.html`, and `pt/contacto.html` while leaving surrounding SEO blocks intact.
- Ensured all pages continue to include their existing `<title>` and `<meta name="description">` tags without modification.
- Committed the changes with message `Remove deprecated keywords meta tags from PT pages` (commit `95189c2`).

### Testing
- Ran `rg -n "<meta name=\"keywords\"" en pt --glob "*.html"` which returned no matches, confirming removal succeeded.
- Executed a Python validation across `en/*.html` and `pt/*.html` to verify each page has a non-empty and reasonably long `<title>` and `<meta name="description">`, which reported `issues 0`.
- Performed a `git commit` which completed successfully and recorded the changes to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f96521408328b0681eb46b31b7cc)