### PR TITLE
Localize theme toggle labels for English and Portuguese pages

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -132,11 +132,14 @@
 
     // Update theme button aria-label
     function updateThemeButtonLabel(button, theme) {
+        const htmlLang = (document.documentElement.getAttribute('lang') || '').toLowerCase();
+        const isPortuguese = htmlLang.startsWith('pt');
+
         const label = theme === 'dark'
-            ? (document.documentElement.lang === 'pt-PT'
+            ? (isPortuguese
                 ? 'Alternar para modo claro'
                 : 'Switch to light mode')
-            : (document.documentElement.lang === 'pt-PT'
+            : (isPortuguese
                 ? 'Alternar para modo escuro'
                 : 'Switch to dark mode');
 

--- a/en/about.html
+++ b/en/about.html
@@ -120,7 +120,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/publications.html">Publications</a>
-        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/en/contact.html
+++ b/en/contact.html
@@ -61,7 +61,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/publications.html">Publications</a>
-        <a href="/en/contact.html" aria-current="page">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html" aria-current="page">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/en/experience.html
+++ b/en/experience.html
@@ -58,7 +58,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html" aria-current="page">Experience</a>
         <a href="/en/publications.html">Publications</a>
-        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/en/index.html
+++ b/en/index.html
@@ -101,7 +101,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/publications.html">Publications</a>
-        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/en/legal.html
+++ b/en/legal.html
@@ -26,7 +26,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/publications.html">Publications</a>
-        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/en/publications.html
+++ b/en/publications.html
@@ -58,7 +58,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/publications.html" aria-current="page">Publications</a>
-        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/en/research.html
+++ b/en/research.html
@@ -58,7 +58,7 @@
         <a href="/en/research.html" aria-current="page">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/publications.html">Publications</a>
-        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+        <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>


### PR DESCRIPTION
### Motivation
- Ensure static theme-toggle attributes on English pages use English text while Portuguese pages keep Portuguese labels for accessibility.
- Make the runtime label updates in `assets/js/script.js` respect the page language instead of a hard-coded locale so toggling remains localized.

### Description
- Updated all English templates under `en/*.html` to use `aria-label="Toggle dark/light theme"` and `title="Toggle theme"` while leaving `pt/*.html` unchanged.
- Modified `updateThemeButtonLabel` in `assets/js/script.js` to read the page language via `document.documentElement.getAttribute('lang')` and compute `isPortuguese` with `startsWith('pt')` before setting localized labels.
- The function now sets English labels (`"Switch to light mode"` / `"Switch to dark mode"`) for non-Portuguese pages and Portuguese labels for pages identified as Portuguese.
- Changes were committed on the working branch and include updated HTML files and the JavaScript file.

### Testing
- Verified updated attributes with `rg -n "theme-toggle\" class=\"theme-toggle\" aria-label=\".*\" title=\".*\"" en/*.html pt/*.html`, which succeeded and shows English labels in `en/*.html` and Portuguese labels in `pt/*.html`.
- Ran a diff check with `git diff` and inspected the commit via `git show --stat --oneline HEAD`, both of which succeeded and show the intended file changes.
- Executed the replacement script (`python` search/replace) and `nl`/file inspections to confirm the `updateThemeButtonLabel` change and modified templates, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f973660c83289a23dee1219eb81d)