### PR TITLE
Widen publications layout with responsive cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1401,3 +1401,54 @@ footer {
         text-align: left;
     }
 }
+/* Publications page: use wide desktop space and present entries as scan-friendly cards */
+.publications-page {
+    width: 100%;
+}
+
+.publications-page .publications-list {
+    display: grid;
+    gap: var(--spacing-sm);
+}
+
+.publications-page .publications-list li {
+    background: var(--secondary-color);
+    border: 1px solid rgba(13, 71, 161, 0.12);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-light);
+    padding: var(--spacing-sm);
+}
+
+@media (min-width: 960px) {
+    main:has(.publications-page),
+    .publications-page {
+        max-width: min(1480px, calc(100vw - 4rem));
+    }
+
+    .publications-page .orcid-info {
+        max-width: 960px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .publications-page .publications-list {
+        grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+        align-items: stretch;
+    }
+}
+
+@media (min-width: 1400px) {
+    main:has(.publications-page),
+    .publications-page {
+        max-width: min(1640px, calc(100vw - 5rem));
+    }
+
+    .publications-page .publications-list {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+[data-theme="dark"] .publications-page .publications-list li {
+    background: #252525;
+    border-color: #3a3a3a;
+}

--- a/en/publications.html
+++ b/en/publications.html
@@ -82,7 +82,7 @@
     </nav>
 
     <main role="main" id="main">
-        <article class="page-content">
+        <article class="page-content publications-page">
             <header class="page-header">
                 <h2>Publications</h2>
                 <p class="lead">Research publications automatically synchronized from ORCID profile</p>

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -84,7 +84,7 @@
     </nav>
 
     <main role="main" id="main">
-        <article class="page-content">
+        <article class="page-content publications-page">
             <header class="page-header">
                 <h2>Publicações</h2>
                 <p class="lead">Publicações de investigação sincronizadas automaticamente do perfil ORCID</p>


### PR DESCRIPTION
Addresses browser review feedback that the publications page wastes horizontal space on desktop.

Changes:
- adds a publications-page class to EN/PT publications pages
- lets the publications page use more viewport width on desktop
- renders generated publication entries as responsive cards in two or three columns where space allows
- preserves single-column mobile behavior and leaves generated ORCID output untouched

Validation plan:
- Site Validation workflow
- browser check at desktop width for wider content and card grid
- browser check at mobile width for no horizontal overflow