### PR TITLE
Improve publications width delivery

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1420,7 +1420,7 @@ footer {
 }
 
 @media (min-width: 960px) {
-    main:has(.publications-page),
+    .publications-main,
     .publications-page {
         max-width: min(1480px, calc(100vw - 4rem));
     }
@@ -1438,7 +1438,7 @@ footer {
 }
 
 @media (min-width: 1400px) {
-    main:has(.publications-page),
+    .publications-main,
     .publications-page {
         max-width: min(1640px, calc(100vw - 5rem));
     }

--- a/en/publications.html
+++ b/en/publications.html
@@ -39,10 +39,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260520-width" as="style">
     <link rel="preload" href="/assets/js/script.js" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260520-width">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to main content</a>
@@ -81,7 +81,7 @@
         </div>
     </nav>
 
-    <main role="main" id="main">
+    <main role="main" id="main" class="publications-main">
         <article class="page-content publications-page">
             <header class="page-header">
                 <h2>Publications</h2>

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -41,10 +41,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260520-width" as="style">
     <link rel="preload" href="/assets/js/script.js" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260520-width">
 </head>
 <body>
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
@@ -83,7 +83,7 @@
         </div>
     </nav>
 
-    <main role="main" id="main">
+    <main role="main" id="main" class="publications-main">
         <article class="page-content publications-page">
             <header class="page-header">
                 <h2>Publicações</h2>


### PR DESCRIPTION
## Summary
- cache-bust the stylesheet on publication pages so the wider layout is loaded immediately
- add an explicit publications main class instead of relying on CSS :has() for the parent width

## Test plan
- GitHub Actions validation
- Pages deploy
- Browser desktop/mobile verification