### PR TITLE
Add static site validation guardrails

### DIFF
--- a/.github/workflows/site-validation.yml
+++ b/.github/workflows/site-validation.yml
@@ -9,70 +9,15 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
-    - name: Validate index.html exists
-      run: |
-        if [ ! -f "index.html" ]; then
-          echo "Error: index.html not found!"
-          exit 1
-        fi
-        echo "✅ index.html found"
-        
-    - name: Validate HTML structure
-      run: |
-        # Check for basic HTML5 structure
-        if ! grep -q "<!DOCTYPE html>" index.html; then
-          echo "Warning: Missing HTML5 doctype"
-        fi
-        if ! grep -q "<header>" index.html; then
-          echo "Warning: Missing header tag"
-        fi
-        if ! grep -q "<nav>" index.html; then
-          echo "Warning: Missing nav tag"
-        fi
-        if ! grep -q "<main>" index.html; then
-          echo "Warning: Missing main tag"
-        fi
-        if ! grep -q "<footer>" index.html; then
-          echo "Warning: Missing footer tag"
-        fi
-        echo "✅ HTML structure validation complete"
-        
-    - name: Optional HTML Lint
-      run: |
-        # Install HTML5 validator (optional)
-        if command -v tidy &> /dev/null; then
-          echo "Running HTML validation with tidy..."
-          tidy -q -e index.html || echo "HTML validation completed with warnings"
-        else
-          echo "Tidy not available, skipping HTML validation"
-        fi
-        
-    - name: Optional CSS Lint
-      run: |
-        # Check if styles.css exists and basic validation
-        if [ -f "styles.css" ]; then
-          echo "✅ styles.css found"
-          # Basic CSS validation - check for obvious syntax errors
-          if grep -q "{" styles.css && grep -q "}" styles.css; then
-            echo "✅ Basic CSS structure looks valid"
-          else
-            echo "Warning: CSS file may have syntax issues"
-          fi
-        else
-          echo "Warning: styles.css not found"
-        fi
-        
-    - name: Output validation info
-      run: |
-        echo "🎉 Site validation complete!"
-        echo ""
-        echo "📄 Files validated:"
-        echo "  ✅ index.html exists and validated"
-        if [ -f "styles.css" ]; then echo "  ✅ styles.css found"; fi
-        if [ -f "script.js" ]; then echo "  ✅ script.js found"; fi
-        echo ""
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Validate static site
+      run: node scripts/validate_site.js

--- a/scripts/validate_site.js
+++ b/scripts/validate_site.js
@@ -56,7 +56,7 @@ check(js.includes('initializeThemeToggle'), 'theme toggle initializer exists');
 for (const page of pages) {
   check(exists(page.file), `${page.file} exists`);
   const html = read(page.file);
-  check(/^<!DOCTYPE html>/i.test(html), `${page.file} has HTML5 doctype`);
+  check(/^\uFEFF?\s*<!DOCTYPE html>/i.test(html), `${page.file} has HTML5 doctype`);
   check(html.includes(`lang="${page.lang}"`), `${page.file} has expected lang`);
   check(/<title>[^<]{10,}<\/title>/.test(html), `${page.file} has descriptive title`);
   check(/<meta name="description" content="[^"]{50,}">/.test(html), `${page.file} has meta description`);

--- a/scripts/validate_site.js
+++ b/scripts/validate_site.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+let failures = 0;
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), 'utf8');
+}
+
+function exists(file) {
+  return fs.existsSync(path.join(root, file));
+}
+
+function check(condition, message) {
+  if (!condition) {
+    failures += 1;
+    console.error(`FAIL ${message}`);
+  } else {
+    console.log(`OK ${message}`);
+  }
+}
+
+const pages = [
+  { file: 'en/index.html', lang: 'en', alternate: '/pt/' },
+  { file: 'en/about.html', lang: 'en', alternate: '/pt/sobre.html' },
+  { file: 'en/research.html', lang: 'en', alternate: '/pt/investigacao.html' },
+  { file: 'en/experience.html', lang: 'en', alternate: '/pt/experiencia.html' },
+  { file: 'en/publications.html', lang: 'en', alternate: '/pt/publicacoes.html' },
+  { file: 'en/contact.html', lang: 'en', alternate: '/pt/contacto.html' },
+  { file: 'pt/index.html', lang: 'pt-PT', alternate: '/en/' },
+  { file: 'pt/sobre.html', lang: 'pt-PT', alternate: '/en/about.html' },
+  { file: 'pt/investigacao.html', lang: 'pt-PT', alternate: '/en/research.html' },
+  { file: 'pt/experiencia.html', lang: 'pt-PT', alternate: '/en/experience.html' },
+  { file: 'pt/publicacoes.html', lang: 'pt-PT', alternate: '/en/publications.html' },
+  { file: 'pt/contacto.html', lang: 'pt-PT', alternate: '/en/contact.html' }
+];
+
+check(exists('index.html'), 'root redirect page exists');
+check(exists('assets/css/styles.css'), 'global stylesheet exists');
+check(exists('assets/js/script.js'), 'global script exists');
+check(exists('sitemap.xml'), 'sitemap exists');
+check(exists('publications/publications_en.html'), 'generated English publications HTML exists');
+check(exists('publications/publications_pt.html'), 'generated Portuguese publications HTML exists');
+
+const css = read('assets/css/styles.css');
+const js = read('assets/js/script.js');
+const sitemap = read('sitemap.xml');
+
+check((css.match(/{/g) || []).length === (css.match(/}/g) || []).length, 'CSS braces are balanced');
+check(css.includes('[data-theme="light"] body'), 'explicit light body override exists');
+check(css.includes('[data-theme="dark"] body'), 'explicit dark body override exists');
+check(css.lastIndexOf('[data-theme="light"] body') > css.lastIndexOf('[data-theme="dark"] body'), 'explicit light override follows dark body rules');
+check(js.includes('initializeThemeToggle'), 'theme toggle initializer exists');
+
+for (const page of pages) {
+  check(exists(page.file), `${page.file} exists`);
+  const html = read(page.file);
+  check(/^<!DOCTYPE html>/i.test(html), `${page.file} has HTML5 doctype`);
+  check(html.includes(`lang="${page.lang}"`), `${page.file} has expected lang`);
+  check(/<title>[^<]{10,}<\/title>/.test(html), `${page.file} has descriptive title`);
+  check(/<meta name="description" content="[^"]{50,}">/.test(html), `${page.file} has meta description`);
+  check(/<link rel="canonical" href="https:\/\/www\.hfmonteiro\.com\//.test(html), `${page.file} has absolute canonical`);
+  check(html.includes('hreflang="en"'), `${page.file} has English hreflang`);
+  check(html.includes('hreflang="pt-PT"'), `${page.file} has Portuguese hreflang`);
+  check(html.includes(`href="${page.alternate}"`) || html.includes(`href="https://www.hfmonteiro.com${page.alternate}"`), `${page.file} links to alternate language page`);
+  check(html.includes('href="/assets/css/styles.css'), `${page.file} links global stylesheet`);
+  check(html.includes('src="/assets/js/script.js"'), `${page.file} loads global script`);
+  check(html.includes('id="theme-toggle"'), `${page.file} has theme toggle`);
+  check(html.includes('class="skip-link"'), `${page.file} has skip link`);
+  check(html.includes('id="main"'), `${page.file} has main landmark target`);
+  check(sitemap.includes(`https://www.hfmonteiro.com/${page.file.replace('index.html', '')}`), `sitemap includes ${page.file}`);
+}
+
+for (const file of ['publications/publications_en.html', 'publications/publications_pt.html']) {
+  const html = read(file);
+  const count = (html.match(/<li>/g) || []).length;
+  check(html.includes('class="publications-list"'), `${file} has publications list`);
+  check(count > 0, `${file} has at least one publication`);
+  check(/\(20\d{2}\)/.test(html), `${file} includes publication years`);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} validation check(s) failed.`);
+  process.exit(1);
+}
+
+console.log('\nSite validation checks passed.');


### PR DESCRIPTION
## Summary
- replace the fragile site validation workflow with a Node-based static validator
- validate bilingual pages, sitemap coverage, global assets, generated publications, and theme override ordering

## Test plan
- GitHub Actions Site Validation