### PR TITLE
Add publication search and filters

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1527,3 +1527,90 @@ footer {
 [data-theme="light"] h2 {
     color: #0d47a1;
 }
+/* Publication filters */
+.publication-tools {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--spacing-sm);
+    align-items: end;
+    margin: var(--spacing-md) 0 var(--spacing-lg);
+    padding: var(--spacing-sm);
+    background: var(--secondary-color);
+    border: 1px solid rgba(13, 71, 161, 0.12);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-light);
+}
+
+.publication-control {
+    display: grid;
+    gap: 0.25rem;
+    color: var(--text-dark);
+    font-weight: 600;
+}
+
+.publication-control input,
+.publication-control select {
+    width: 100%;
+    min-height: 42px;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid rgba(13, 71, 161, 0.22);
+    border-radius: var(--border-radius-small);
+    background: var(--white);
+    color: var(--text-dark);
+    font: inherit;
+}
+
+.publication-reset {
+    min-height: 42px;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid rgba(13, 71, 161, 0.28);
+    border-radius: var(--border-radius-small);
+    background: var(--white);
+    color: var(--primary-color);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+}
+
+.publication-reset:hover,
+.publication-reset:focus {
+    background: var(--primary-color);
+    color: #ffffff;
+}
+
+.publication-filter-status {
+    grid-column: 1 / -1;
+    margin: 0;
+}
+
+.publication-no-results {
+    margin-top: var(--spacing-sm);
+}
+
+[data-theme="dark"] .publication-tools {
+    background: #252525;
+    border-color: #3a3a3a;
+}
+
+[data-theme="dark"] .publication-control,
+[data-theme="dark"] .publication-control input,
+[data-theme="dark"] .publication-control select {
+    color: #e8e8e8;
+}
+
+[data-theme="dark"] .publication-control input,
+[data-theme="dark"] .publication-control select,
+[data-theme="dark"] .publication-reset {
+    background: #1a1a1a;
+    border-color: #4a5f7f;
+}
+
+[data-theme="dark"] .publication-reset {
+    color: #6ba3e8;
+}
+
+[data-theme="dark"] .publication-reset:hover,
+[data-theme="dark"] .publication-reset:focus {
+    background: #1e3a5f;
+    color: #ffffff;
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -359,6 +359,125 @@
         }
     }
     
+
+    // Publication search and filters for asynchronously loaded ORCID output
+    function initializePublicationFilters(options) {
+        const defaults = {
+            searchLabel: 'Search publications',
+            searchPlaceholder: 'Search by title, journal, year, or DOI',
+            yearLabel: 'Year',
+            allYearsLabel: 'All years',
+            typeLabel: 'Type',
+            allTypesLabel: 'All types',
+            journalLabel: 'Journal articles',
+            otherLabel: 'Other outputs',
+            resetLabel: 'Reset',
+            resultLabel: 'publication shown',
+            resultsLabel: 'publications shown',
+            noResultsLabel: 'No publications match the current filters.'
+        };
+        const labels = Object.assign({}, defaults, options || {});
+        const container = document.getElementById('publications-content');
+        if (!container || container.querySelector('.publication-tools')) return;
+
+        const list = container.querySelector('.publications-list');
+        if (!list) return;
+
+        const items = Array.from(list.querySelectorAll('li'));
+        if (items.length === 0) return;
+
+        const years = new Set();
+        items.forEach((item) => {
+            const text = item.textContent || '';
+            const yearMatch = text.match(/\((20\d{2}|19\d{2})\)/);
+            const year = yearMatch ? yearMatch[1] : '';
+            const type = /conference|proceedings|poster|abstract|report/i.test(text) ? 'other' : 'journal';
+            item.dataset.publicationYear = year;
+            item.dataset.publicationType = type;
+            item.dataset.publicationText = text.toLowerCase();
+            if (year) years.add(year);
+        });
+
+        const tools = document.createElement('div');
+        tools.className = 'publication-tools';
+        tools.innerHTML = `
+            <label class="publication-control">
+                <span>${labels.searchLabel}</span>
+                <input type="search" class="publication-search" placeholder="${labels.searchPlaceholder}" autocomplete="off">
+            </label>
+            <label class="publication-control">
+                <span>${labels.yearLabel}</span>
+                <select class="publication-year">
+                    <option value="">${labels.allYearsLabel}</option>
+                </select>
+            </label>
+            <label class="publication-control">
+                <span>${labels.typeLabel}</span>
+                <select class="publication-type">
+                    <option value="">${labels.allTypesLabel}</option>
+                    <option value="journal">${labels.journalLabel}</option>
+                    <option value="other">${labels.otherLabel}</option>
+                </select>
+            </label>
+            <button type="button" class="publication-reset">${labels.resetLabel}</button>
+            <p class="publication-filter-status meta" aria-live="polite"></p>
+        `;
+
+        const yearSelect = tools.querySelector('.publication-year');
+        Array.from(years).sort((a, b) => Number(b) - Number(a)).forEach((year) => {
+            const option = document.createElement('option');
+            option.value = year;
+            option.textContent = year;
+            yearSelect.appendChild(option);
+        });
+
+        const noResults = document.createElement('p');
+        noResults.className = 'publication-no-results error-message';
+        noResults.textContent = labels.noResultsLabel;
+        noResults.hidden = true;
+
+        list.parentNode.insertBefore(tools, list);
+        list.parentNode.insertBefore(noResults, list.nextSibling);
+
+        const searchInput = tools.querySelector('.publication-search');
+        const typeSelect = tools.querySelector('.publication-type');
+        const resetButton = tools.querySelector('.publication-reset');
+        const status = tools.querySelector('.publication-filter-status');
+
+        function applyFilters() {
+            const query = searchInput.value.trim().toLowerCase();
+            const selectedYear = yearSelect.value;
+            const selectedType = typeSelect.value;
+            let visibleCount = 0;
+
+            items.forEach((item) => {
+                const matchesQuery = !query || item.dataset.publicationText.includes(query);
+                const matchesYear = !selectedYear || item.dataset.publicationYear === selectedYear;
+                const matchesType = !selectedType || item.dataset.publicationType === selectedType;
+                const visible = matchesQuery && matchesYear && matchesType;
+                item.hidden = !visible;
+                if (visible) visibleCount += 1;
+            });
+
+            noResults.hidden = visibleCount !== 0;
+            status.textContent = `${visibleCount} ${visibleCount === 1 ? labels.resultLabel : labels.resultsLabel}`;
+        }
+
+        searchInput.addEventListener('input', applyFilters);
+        yearSelect.addEventListener('change', applyFilters);
+        typeSelect.addEventListener('change', applyFilters);
+        resetButton.addEventListener('click', () => {
+            searchInput.value = '';
+            yearSelect.value = '';
+            typeSelect.value = '';
+            applyFilters();
+            searchInput.focus();
+        });
+
+        applyFilters();
+    }
+    window.initializePublicationFilters = initializePublicationFilters;
+
     // Fallback initialization for older browsers
     function fallbackInitialization() {
         console.log('Running fallback initialization');

--- a/en/publications.html
+++ b/en/publications.html
@@ -147,7 +147,26 @@
         document.addEventListener('DOMContentLoaded', function() {
             fetch('/publications/publications_en.html')
                 .then(r => { if (!r.ok) throw new Error('Load failed'); return r.text(); })
-                .then(html => { document.getElementById('publications-content').innerHTML = html; })
+                .then(html => {
+                    const content = document.getElementById('publications-content');
+                    content.innerHTML = html;
+                    if (window.initializePublicationFilters) {
+                        window.initializePublicationFilters({
+                            searchLabel: 'Search publications',
+                            searchPlaceholder: 'Search by title, journal, year, or DOI',
+                            yearLabel: 'Year',
+                            allYearsLabel: 'All years',
+                            typeLabel: 'Type',
+                            allTypesLabel: 'All types',
+                            journalLabel: 'Journal articles',
+                            otherLabel: 'Other outputs',
+                            resetLabel: 'Reset',
+                            resultLabel: 'publication shown',
+                            resultsLabel: 'publications shown',
+                            noResultsLabel: 'No publications match the current filters.'
+                        });
+                    }
+                })
                 .catch(() => {
                     document.getElementById('publications-content').innerHTML =
                         '<p class="error-message">Unable to load publications. Please visit my <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener">ORCID profile</a>.</p>';

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -149,7 +149,26 @@
         document.addEventListener('DOMContentLoaded', function() {
             fetch('/publications/publications_pt.html')
                 .then(r => { if (!r.ok) throw new Error('Load failed'); return r.text(); })
-                .then(html => { document.getElementById('publications-content').innerHTML = html; })
+                .then(html => {
+                    const content = document.getElementById('publications-content');
+                    content.innerHTML = html;
+                    if (window.initializePublicationFilters) {
+                        window.initializePublicationFilters({
+                            searchLabel: 'Pesquisar publicacoes',
+                            searchPlaceholder: 'Pesquisar por titulo, revista, ano ou DOI',
+                            yearLabel: 'Ano',
+                            allYearsLabel: 'Todos os anos',
+                            typeLabel: 'Tipo',
+                            allTypesLabel: 'Todos os tipos',
+                            journalLabel: 'Artigos em revistas',
+                            otherLabel: 'Outros resultados',
+                            resetLabel: 'Limpar',
+                            resultLabel: 'publicacao apresentada',
+                            resultsLabel: 'publicacoes apresentadas',
+                            noResultsLabel: 'Nenhuma publicacao corresponde aos filtros atuais.'
+                        });
+                    }
+                })
                 .catch(() => {
                     document.getElementById('publications-content').innerHTML = 
                         '<p class="error-message">Não foi possível carregar as publicações neste momento. Por favor visite o meu <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener">perfil ORCID</a> para a lista mais atual.</p>';


### PR DESCRIPTION
## Summary
- add client-side publication search and filters for year/type
- initialize filters after ORCID-generated HTML is loaded, without editing generated publication files
- style controls for light and dark modes

## Test plan
- GitHub Actions Site Validation
- Browser check for EN/PT publication filtering