### PR TITLE
Remove invalid X-Frame-Options meta tags

### DIFF
--- a/en/contact.html
+++ b/en/contact.html
@@ -33,8 +33,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Favicon -->

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -32,8 +32,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Favicon -->

--- a/pt/experiencia.html
+++ b/pt/experiencia.html
@@ -32,8 +32,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Favicon -->

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -32,8 +32,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Favicon -->

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -32,8 +32,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Favicon -->

--- a/pt/sobre.html
+++ b/pt/sobre.html
@@ -32,8 +32,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+<meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Favicon -->

--- a/scripts/validate_site.js
+++ b/scripts/validate_site.js
@@ -69,6 +69,7 @@ for (const page of pages) {
   check(html.includes('id="theme-toggle"'), `${page.file} has theme toggle`);
   check(html.includes('class="skip-link"'), `${page.file} has skip link`);
   check(html.includes('id="main"'), `${page.file} has main landmark target`);
+  check(!/<meta\s+http-equiv="X-Frame-Options"/i.test(html), `${page.file} does not set X-Frame-Options via meta`);
   check(sitemap.includes(`https://www.hfmonteiro.com/${page.file.replace('index.html', '')}`), `sitemap includes ${page.file}`);
 }
 


### PR DESCRIPTION
## Summary
- remove X-Frame-Options meta tags that browsers ignore and report as console errors
- add validation coverage so the issue does not come back

## Test plan
- GitHub Actions Site Validation
- Browser console check on PT publications