### PR TITLE
Force refresh for page header readability fix

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1642,3 +1642,12 @@ main .page-header .lead {
 [data-theme="dark"] main .page-header .lead {
     color: #c4c4c4;
 }
+[data-theme="light"] main .page-header {
+    background: transparent;
+    color: #111111;
+    box-shadow: none;
+}
+
+[data-theme="light"] main .page-header .lead {
+    color: #444444;
+}

--- a/en/about.html
+++ b/en/about.html
@@ -39,10 +39,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/en/contact.html
+++ b/en/contact.html
@@ -41,10 +41,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to main content</a>

--- a/en/experience.html
+++ b/en/experience.html
@@ -39,10 +39,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to main content</a>

--- a/en/index.html
+++ b/en/index.html
@@ -39,9 +39,9 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/en/legal.html
+++ b/en/legal.html
@@ -9,8 +9,8 @@
     <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/legal.html">
     <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/legal.html">
     <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/legal.html">
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
 </head>

--- a/en/publications.html
+++ b/en/publications.html
@@ -39,10 +39,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to main content</a>

--- a/en/research.html
+++ b/en/research.html
@@ -39,10 +39,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to main content</a>

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -40,10 +40,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>

--- a/pt/experiencia.html
+++ b/pt/experiencia.html
@@ -40,10 +40,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -38,9 +38,9 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -40,10 +40,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>

--- a/pt/legal.html
+++ b/pt/legal.html
@@ -9,8 +9,8 @@
     <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/legal.html">
     <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/legal.html">
     <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/legal.html">
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
 </head>

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -40,10 +40,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
 </head>
 <body>
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>

--- a/pt/sobre.html
+++ b/pt/sobre.html
@@ -40,10 +40,10 @@
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/assets/css/styles.css?v=20260521" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-header" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
     
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-header">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- bump stylesheet version across bilingual pages so browsers fetch the page-header readability fix
- add explicit light-mode page-header rules as a guardrail

## Test plan
- GitHub Actions Site Validation
- Browser check on PT experience/publications in light mode