### PR TITLE
Add Featured case-study sections and supporting project cards to projects pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1770,6 +1770,7 @@ section h3 {
 .projects-list,
 .publications-page .publications-list,
 .project-index,
+.featured-projects-grid,
 .method-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
@@ -1906,6 +1907,80 @@ section h3 {
   align-items: stretch;
 }
 
+.section-heading {
+  max-width: 940px;
+  margin-bottom: 1rem;
+}
+
+.section-heading p:not(.eyebrow) {
+  margin: 0;
+  color: var(--text-color);
+}
+
+.featured-work,
+.additional-work {
+  border-bottom: 0;
+}
+
+.featured-projects-grid {
+  align-items: stretch;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr));
+}
+
+.project-card.featured-project-card {
+  position: relative;
+  padding: clamp(1.2rem, 1.8vw, 1.65rem);
+  border-left-width: 6px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbfe 100%);
+  box-shadow: 0 8px 24px rgba(15, 76, 129, 0.08);
+}
+
+.project-card.featured-project-card h4 {
+  font-size: clamp(1.28rem, 1.04rem + 0.55vw, 1.62rem);
+}
+
+.project-card.featured-project-card .project-summary {
+  font-size: clamp(1rem, 0.95rem + 0.16vw, 1.1rem);
+}
+
+.project-card.featured-project-card .project-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.15rem;
+  min-height: 2.15rem;
+  border-radius: 999px;
+  background: #e9f3fb;
+}
+
+.case-study-facts {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 230px), 1fr));
+  gap: 0.7rem;
+}
+
+.case-study-facts div {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #d7e3ee;
+  border-left: 3px solid var(--secondary-color);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.project-card.supporting-project-card {
+  border-left-width: 3px;
+  background: #fbfcfe;
+  box-shadow: none;
+}
+
+.project-card.supporting-project-card .project-summary,
+.project-card.supporting-project-card .project-facts dd {
+  color: #3f5062;
+}
+
+.project-card.supporting-project-card .project-tags span {
+  background: #ffffff;
+}
+
 .project-card {
   display: flex;
   flex-direction: column;
@@ -2029,6 +2104,30 @@ section h3 {
   background: #1b2633;
 }
 
+[data-theme="dark"] .project-card.featured-project-card {
+  background: linear-gradient(180deg, #252525 0%, #202832 100%);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.24);
+}
+
+[data-theme="dark"] .project-card.featured-project-card .project-number {
+  background: #1b2633;
+}
+
+[data-theme="dark"] .case-study-facts div {
+  border-color: #385066;
+  border-left-color: var(--secondary-color);
+  background: rgba(27, 38, 51, 0.52);
+}
+
+[data-theme="dark"] .project-card.supporting-project-card {
+  background: #222222;
+}
+
+[data-theme="dark"] .project-card.supporting-project-card .project-summary,
+[data-theme="dark"] .project-card.supporting-project-card .project-facts dd {
+  color: #d6e5f2;
+}
+
 [data-theme="dark"] .experience-timeline .timeline-content {
   background: #252525;
   border-color: #385066;
@@ -2091,7 +2190,8 @@ section h3 {
 
   .projects-list,
   .publications-page .publications-list,
-  .project-index {
+  .project-index,
+  .featured-projects-grid {
     grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   }
 
@@ -2113,6 +2213,10 @@ section h3 {
 
   .publications-page .publications-list,
   .project-index {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .featured-projects-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 

--- a/en/projects.html
+++ b/en/projects.html
@@ -27,9 +27,9 @@
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
-    <link rel="preload" href="/assets/css/styles.css?v=20260521-v2projects" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260605-featured-projects" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-v2projects">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260605-featured-projects">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to main content</a>
@@ -77,153 +77,290 @@
                 </div>
             </section>
 
-            <section class="project-index" aria-label="Selected projects">
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">01</span>
-                        <p class="project-meta">Public health planning</p>
-                    </div>
-                    <h4>Health Situation Diagnosis and Municipal Health Planning</h4>
-                    <p class="project-summary">Population evidence structured to support local priorities and public-health planning decisions.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Indicators, territory, health needs and operational interpretation for public decision-making.</dd>
+            <section class="featured-work" aria-labelledby="featured-work-heading">
+                <div class="section-heading">
+                    <p class="eyebrow">Case studies</p>
+                    <h3 id="featured-work-heading">Featured Work</h3>
+                    <p>Three larger case-study cards highlight applied public-health and digital-transformation work described at a public, aggregate level.</p>
+                </div>
+                <div class="featured-projects-grid">
+                    <article id="episignal" class="project-card featured-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">01</span>
+                            <p class="project-meta">Surveillance demonstrator</p>
                         </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>A clearer working basis for local discussion without exposing personal or sensitive information.</dd>
+                        <h4>Episignal Public-Health Signal Review Prototype</h4>
+                        <p class="project-summary">A governed prototype for structuring public-health signals so teams can review, interpret and prioritise information without exposing personal data.</p>
+                        <dl class="project-facts case-study-facts">
+                            <div>
+                                <dt>Problem</dt>
+                                <dd>Signals from surveillance, operations and contextual information can be hard to compare when they arrive through fragmented formats.</dd>
+                            </div>
+                            <div>
+                                <dt>Context</dt>
+                                <dd>Public-health teams need public, aggregate and reviewable views that support situational awareness while preserving caution around sensitive information.</dd>
+                            </div>
+                            <div>
+                                <dt>My role</dt>
+                                <dd>Helped structure the problem, information model, review logic and communication approach for a demonstrator.</dd>
+                            </div>
+                            <div>
+                                <dt>Methods/tools</dt>
+                                <dd>Indicator framing, workflow mapping, dashboard concepts, data-quality checks and human-in-the-loop review patterns.</dd>
+                            </div>
+                            <div>
+                                <dt>Governance and human review or data protection</dt>
+                                <dd>Designed around aggregate information, traceable assumptions and human review before interpretation or escalation.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>A prototype that creates visibility over signals and provides a basis for discussion and decision-making.</dd>
+                            </div>
+                            <div>
+                                <dt>What it demonstrates</dt>
+                                <dd>How governed digital tools can support surveillance work without replacing professional judgement.</dd>
+                            </div>
+                            <div>
+                                <dt>Transferability</dt>
+                                <dd>The same pattern can support other population-health monitoring topics that require transparent review and careful interpretation.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Surveillance</span>
+                            <span>Signals</span>
+                            <span>Governance</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Public health</span>
-                        <span>Planning</span>
-                        <span>Indicators</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">02</span>
-                        <p class="project-meta">Programme monitoring</p>
-                    </div>
-                    <h4>Screening Programme Dashboards</h4>
-                    <p class="project-summary">Monitoring views that make screening programmes easier to follow, prioritise and manage.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Prioritisation, exceptions, monitoring cadence and rapid performance interpretation.</dd>
+                    </article>
+
+                    <article id="uls-pls-digital" class="project-card featured-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">02</span>
+                            <p class="project-meta">Planning and population health</p>
                         </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>Less reliance on ad hoc analysis and better operational visibility.</dd>
+                        <h4>ULS / PLS Digital Planning Demonstrator</h4>
+                        <p class="project-summary">A digital planning demonstrator that helps structure local-health evidence, priorities and review points for population-health planning.</p>
+                        <dl class="project-facts case-study-facts">
+                            <div>
+                                <dt>Problem</dt>
+                                <dd>Planning work can depend on dispersed indicators, documents and local interpretations that are difficult to keep aligned.</dd>
+                            </div>
+                            <div>
+                                <dt>Context</dt>
+                                <dd>Local Health Units and Local Health Plans require a shared evidence base that remains explainable and safe to discuss publicly at aggregate level.</dd>
+                            </div>
+                            <div>
+                                <dt>My role</dt>
+                                <dd>Supported the framing of planning needs, indicator organisation, stakeholder questions and practical outputs.</dd>
+                            </div>
+                            <div>
+                                <dt>Methods/tools</dt>
+                                <dd>Population-health indicators, territory profiles, planning logic, data visualisation and structured documentation.</dd>
+                            </div>
+                            <div>
+                                <dt>Governance and human review or data protection</dt>
+                                <dd>Uses aggregate information, avoids personal identifiers and keeps interpretation reviewable by accountable professionals.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>A demonstrator that supports planning conversations and provides a basis for decision-making without claiming automated prioritisation.</dd>
+                            </div>
+                            <div>
+                                <dt>What it demonstrates</dt>
+                                <dd>How public-health planning can become more transparent when evidence, assumptions and decisions are organised together.</dd>
+                            </div>
+                            <div>
+                                <dt>Transferability</dt>
+                                <dd>The approach can be adapted to other municipal, regional or programme-planning contexts where evidence needs to be reviewed collaboratively.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Public health</span>
+                            <span>Planning</span>
+                            <span>Indicators</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Dashboards</span>
-                        <span>Screening</span>
-                        <span>Data</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">03</span>
-                        <p class="project-meta">Surveillance and reporting</p>
-                    </div>
-                    <h4>Digital Surveillance Bulletins</h4>
-                    <p class="project-summary">More consistent production of public-health bulletins and recurring communication products.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Data preparation, repeatable routines and clear public-health communication.</dd>
+                    </article>
+
+                    <article id="screening-dashboards" class="project-card featured-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">03</span>
+                            <p class="project-meta">Programme monitoring</p>
                         </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>Reduced manual work and greater consistency across periodic publications.</dd>
+                        <h4>Screening Programme Dashboards</h4>
+                        <p class="project-summary">Monitoring dashboard prototypes that create visibility over screening programmes and help structure review, prioritisation and follow-up.</p>
+                        <dl class="project-facts case-study-facts">
+                            <div>
+                                <dt>Problem</dt>
+                                <dd>Screening programmes need consistent ways to follow status, exceptions and operational priorities across time.</dd>
+                            </div>
+                            <div>
+                                <dt>Context</dt>
+                                <dd>Programme monitoring benefits from clear views that can be discussed by public-health and operational teams without exposing identifiable data.</dd>
+                            </div>
+                            <div>
+                                <dt>My role</dt>
+                                <dd>Helped translate programme questions into monitoring views, indicators, review routines and safe communication formats.</dd>
+                            </div>
+                            <div>
+                                <dt>Methods/tools</dt>
+                                <dd>BI dashboard design, indicator definitions, prioritisation logic, exception lists and data-quality checks.</dd>
+                            </div>
+                            <div>
+                                <dt>Governance and human review or data protection</dt>
+                                <dd>Designed for aggregate or role-appropriate review, with human interpretation of exceptions and no claim of automated decision-making.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>Dashboard prototypes that support recurring programme review and provide a basis for decision-making.</dd>
+                            </div>
+                            <div>
+                                <dt>What it demonstrates</dt>
+                                <dd>How data visualisation can help teams see programme status and structure operational conversations.</dd>
+                            </div>
+                            <div>
+                                <dt>Transferability</dt>
+                                <dd>The monitoring pattern can be reused for other preventive, population-health or pathway programmes.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Dashboards</span>
+                            <span>Screening</span>
+                            <span>Data</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Surveillance</span>
-                        <span>Automation</span>
-                        <span>Reporting</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">04</span>
-                        <p class="project-meta">Administrative digitalisation</p>
-                    </div>
-                    <h4>Sanitary Pool Records</h4>
-                    <p class="project-summary">Moving paper-based administrative processes into records that are easier to consult and audit.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Administrative requirements, traceability, team adoption and document clarity.</dd>
+                    </article>
+                </div>
+            </section>
+
+            <section class="additional-work" aria-labelledby="additional-work-heading">
+                <div class="section-heading">
+                    <p class="eyebrow">Supporting portfolio</p>
+                    <h3 id="additional-work-heading">Additional Applied Work</h3>
+                    <p>Shorter secondary cards preserve other public-health and digital-transformation material in safe, aggregate terms.</p>
+                </div>
+                <div class="project-index supporting-projects-grid" aria-label="Additional applied work">
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A1</span>
+                            <p class="project-meta">Public health planning</p>
                         </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>A more transparent workflow with less friction in record management.</dd>
+                        <h4>Health Situation Diagnosis and Municipal Health Planning</h4>
+                        <p class="project-summary">Population evidence structured to support local priorities and public-health planning decisions.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Focus</dt>
+                                <dd>Indicators, territory, health needs and operational interpretation for public decision-making.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>A clearer working basis for local discussion without exposing personal or sensitive information.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Public health</span>
+                            <span>Planning</span>
+                            <span>Indicators</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>GovTech</span>
-                        <span>Records</span>
-                        <span>Process</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">05</span>
-                        <p class="project-meta">Care pathways</p>
-                    </div>
-                    <h4>ICTUSnet and Pathway Coordination</h4>
-                    <p class="project-summary">Collaborative work around stroke pathways, shared information and coordination between teams.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Interoperability, response times, data quality and stakeholder alignment.</dd>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A2</span>
+                            <p class="project-meta">Surveillance and reporting</p>
                         </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>A clearer shared frame for clinical, operational and technology decisions.</dd>
+                        <h4>Digital Surveillance Bulletins</h4>
+                        <p class="project-summary">Repeatable bulletin workflows that support consistent public-health communication and recurring aggregate reporting.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Focus</dt>
+                                <dd>Data preparation, repeatable routines and clear public-health communication.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>More consistent periodic publications and less dependence on ad hoc formatting.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Surveillance</span>
+                            <span>Automation</span>
+                            <span>Reporting</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Pathways</span>
-                        <span>Interoperability</span>
-                        <span>Collaboration</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">06</span>
-                        <p class="project-meta">Applied AI and data science</p>
-                    </div>
-                    <h4>AI, NLP and GIS Prototypes</h4>
-                    <p class="project-summary">Practical exploration of AI, text processing and geospatial analysis in public-health problems.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Technical feasibility, operational usefulness, privacy, governance and human review.</dd>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A3</span>
+                            <p class="project-meta">Administrative digitalisation</p>
                         </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>Clearer criteria for deciding which ideas should move from prototype to implementation.</dd>
+                        <h4>Sanitary Pool Records</h4>
+                        <p class="project-summary">Digital record structures that make administrative health processes easier to consult, trace and review.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Focus</dt>
+                                <dd>Administrative requirements, traceability, team-use considerations and document clarity.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>A more transparent workflow with less friction in record management.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>GovTech</span>
+                            <span>Records</span>
+                            <span>Process</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>AI</span>
-                        <span>NLP</span>
-                        <span>GIS</span>
-                        <span>Governance</span>
-                    </div>
-                </article>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A4</span>
+                            <p class="project-meta">Care pathways</p>
+                        </div>
+                        <h4>ICTUSnet and Pathway Coordination</h4>
+                        <p class="project-summary">Collaborative work around stroke pathways, shared information and coordination between teams.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Focus</dt>
+                                <dd>Interoperability, response times, data quality and stakeholder alignment.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>A clearer shared frame for clinical, operational and technology decisions.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Pathways</span>
+                            <span>Interoperability</span>
+                            <span>Collaboration</span>
+                        </div>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A5</span>
+                            <p class="project-meta">Applied AI and data science</p>
+                        </div>
+                        <h4>AI, NLP and GIS Prototypes</h4>
+                        <p class="project-summary">Practical prototypes exploring AI, text processing and geospatial analysis in public-health problems.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Focus</dt>
+                                <dd>Technical feasibility, operational usefulness, privacy, governance and human review.</dd>
+                            </div>
+                            <div>
+                                <dt>Output</dt>
+                                <dd>Clearer criteria for deciding which ideas should move from prototype to accountable next steps.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>AI</span>
+                            <span>NLP</span>
+                            <span>GIS</span>
+                            <span>Governance</span>
+                        </div>
+                    </article>
+                </div>
             </section>
 
             <section class="projects-method">
                 <h3>How This Work Is Run</h3>
                 <div class="method-grid">
                     <div><h4>Decision clarity</h4><p>Start with who decides, at what cadence, and which indicator changes action.</p></div>
-                    <div><h4>Realistic maintenance</h4><p>Prefer solutions teams can update, explain and audit after launch.</p></div>
+                    <div><h4>Realistic maintenance</h4><p>Prefer solutions teams can update, explain and audit over time.</p></div>
                     <div><h4>Visible governance</h4><p>Treat privacy, traceability and human accountability as design requirements.</p></div>
                 </div>
             </section>

--- a/pt/projetos.html
+++ b/pt/projetos.html
@@ -27,9 +27,9 @@
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
     <link rel="icon" type="image/png" href="/assets/img/favicon.png">
-    <link rel="preload" href="/assets/css/styles.css?v=20260521-v2projects" as="style">
+    <link rel="preload" href="/assets/css/styles.css?v=20260605-featured-projects" as="style">
     <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
-    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-v2projects">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260605-featured-projects">
 </head>
 <body>
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
@@ -77,153 +77,290 @@
                 </div>
             </section>
 
-            <section class="project-index" aria-label="Projetos selecionados">
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">01</span>
-                        <p class="project-meta">Planeamento em saúde pública</p>
-                    </div>
-                    <h4>Diagnóstico de Situação de Saúde e Planeamento Municipal</h4>
-                    <p class="project-summary">Organização de evidência populacional para apoiar prioridades locais e decisões de planeamento.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Indicadores, território, necessidades de saúde e leitura operacional para decisão pública.</dd>
+            <section class="featured-work" aria-labelledby="featured-work-heading">
+                <div class="section-heading">
+                    <p class="eyebrow">Estudos de caso</p>
+                    <h3 id="featured-work-heading">Trabalho em Destaque</h3>
+                    <p>Três cartões maiores destacam trabalho aplicado em saúde pública e transformação digital, descrito de forma pública e agregada.</p>
+                </div>
+                <div class="featured-projects-grid">
+                    <article id="episignal" class="project-card featured-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">01</span>
+                            <p class="project-meta">Demonstrador de vigilância</p>
                         </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Base de trabalho clara para discussão local, sem expor dados pessoais ou informação sensível.</dd>
+                        <h4>Protótipo Episignal para Revisão de Sinais em Saúde Pública</h4>
+                        <p class="project-summary">Protótipo com governação para estruturar sinais de saúde pública, permitindo rever, interpretar e priorizar informação sem expor dados pessoais.</p>
+                        <dl class="project-facts case-study-facts">
+                            <div>
+                                <dt>Problema</dt>
+                                <dd>Sinais de vigilância, operação e contexto podem ser difíceis de comparar quando chegam em formatos fragmentados.</dd>
+                            </div>
+                            <div>
+                                <dt>Contexto</dt>
+                                <dd>Equipas de saúde pública precisam de vistas públicas, agregadas e auditáveis que apoiem consciência situacional com cautela sobre informação sensível.</dd>
+                            </div>
+                            <div>
+                                <dt>O meu papel</dt>
+                                <dd>Apoiei a estruturação do problema, do modelo de informação, da lógica de revisão e da abordagem de comunicação para um demonstrador.</dd>
+                            </div>
+                            <div>
+                                <dt>Métodos/ferramentas</dt>
+                                <dd>Enquadramento de indicadores, mapeamento de fluxos, conceitos de dashboard, validações de qualidade dos dados e padrões de revisão humana.</dd>
+                            </div>
+                            <div>
+                                <dt>Governação e revisão humana ou proteção de dados</dt>
+                                <dd>Desenho orientado para informação agregada, pressupostos rastreáveis e revisão humana antes de interpretação ou escalamento.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Protótipo que cria visibilidade sobre sinais e fornece uma base para discussão e tomada de decisão.</dd>
+                            </div>
+                            <div>
+                                <dt>O que demonstra</dt>
+                                <dd>Como ferramentas digitais com governação podem apoiar trabalho de vigilância sem substituir o julgamento profissional.</dd>
+                            </div>
+                            <div>
+                                <dt>Transferibilidade</dt>
+                                <dd>O mesmo padrão pode apoiar outros temas de monitorização em saúde populacional que exigem revisão transparente e interpretação cuidadosa.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Vigilância</span>
+                            <span>Sinais</span>
+                            <span>Governação</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Saúde pública</span>
-                        <span>Planeamento</span>
-                        <span>Indicadores</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">02</span>
-                        <p class="project-meta">Monitorização de programas</p>
-                    </div>
-                    <h4>Dashboards de Programas de Rastreio</h4>
-                    <p class="project-summary">Vistas de acompanhamento para tornar programas de rastreio mais fáceis de monitorizar e gerir.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Priorização, exceções, cadência de acompanhamento e leitura rápida de desempenho.</dd>
+                    </article>
+
+                    <article id="uls-pls-digital" class="project-card featured-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">02</span>
+                            <p class="project-meta">Planeamento e saúde populacional</p>
                         </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Menos dependência de análises avulsas e melhor visibilidade operacional.</dd>
+                        <h4>Demonstrador Digital ULS / PLS</h4>
+                        <p class="project-summary">Demonstrador digital de planeamento que ajuda a estruturar evidência local, prioridades e pontos de revisão para planeamento em saúde populacional.</p>
+                        <dl class="project-facts case-study-facts">
+                            <div>
+                                <dt>Problema</dt>
+                                <dd>O planeamento pode depender de indicadores, documentos e interpretações locais dispersas, difíceis de manter alinhadas.</dd>
+                            </div>
+                            <div>
+                                <dt>Contexto</dt>
+                                <dd>Unidades Locais de Saúde e Planos Locais de Saúde precisam de uma base de evidência comum, explicável e segura para discussão pública agregada.</dd>
+                            </div>
+                            <div>
+                                <dt>O meu papel</dt>
+                                <dd>Apoiei o enquadramento das necessidades de planeamento, a organização de indicadores, as perguntas dos stakeholders e os produtos práticos.</dd>
+                            </div>
+                            <div>
+                                <dt>Métodos/ferramentas</dt>
+                                <dd>Indicadores de saúde populacional, perfis territoriais, lógica de planeamento, visualização de dados e documentação estruturada.</dd>
+                            </div>
+                            <div>
+                                <dt>Governação e revisão humana ou proteção de dados</dt>
+                                <dd>Usa informação agregada, evita identificadores pessoais e mantém a interpretação passível de revisão por profissionais responsáveis.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Demonstrador que apoia conversas de planeamento e fornece uma base para tomada de decisão, sem alegar priorização automática.</dd>
+                            </div>
+                            <div>
+                                <dt>O que demonstra</dt>
+                                <dd>Como o planeamento em saúde pública pode ganhar transparência quando evidência, pressupostos e decisões são organizados em conjunto.</dd>
+                            </div>
+                            <div>
+                                <dt>Transferibilidade</dt>
+                                <dd>A abordagem pode ser adaptada a outros contextos municipais, regionais ou programáticos onde a evidência deve ser revista de forma colaborativa.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Saúde pública</span>
+                            <span>Planeamento</span>
+                            <span>Indicadores</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Dashboards</span>
-                        <span>Rastreios</span>
-                        <span>Dados</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">03</span>
-                        <p class="project-meta">Vigilância e reporte</p>
-                    </div>
-                    <h4>Boletins de Vigilância Digitais</h4>
-                    <p class="project-summary">Produção mais consistente de boletins e produtos periódicos de comunicação em saúde pública.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Preparação de dados, rotinas repetíveis e clareza de comunicação.</dd>
+                    </article>
+
+                    <article id="screening-dashboards" class="project-card featured-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">03</span>
+                            <p class="project-meta">Monitorização de programas</p>
                         </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Redução de trabalho manual e maior consistência entre publicações periódicas.</dd>
+                        <h4>Dashboards de Programas de Rastreio</h4>
+                        <p class="project-summary">Protótipos de dashboards de monitorização que criam visibilidade sobre programas de rastreio e ajudam a estruturar revisão, priorização e seguimento.</p>
+                        <dl class="project-facts case-study-facts">
+                            <div>
+                                <dt>Problema</dt>
+                                <dd>Programas de rastreio precisam de formas consistentes de acompanhar estado, exceções e prioridades operacionais ao longo do tempo.</dd>
+                            </div>
+                            <div>
+                                <dt>Contexto</dt>
+                                <dd>A monitorização de programas beneficia de vistas claras que podem ser discutidas por equipas de saúde pública e operacionais sem expor dados identificáveis.</dd>
+                            </div>
+                            <div>
+                                <dt>O meu papel</dt>
+                                <dd>Apoiei a tradução de perguntas programáticas em vistas de monitorização, indicadores, rotinas de revisão e formatos seguros de comunicação.</dd>
+                            </div>
+                            <div>
+                                <dt>Métodos/ferramentas</dt>
+                                <dd>Desenho de dashboards de BI, definições de indicadores, lógica de priorização, listas de exceções e validações de qualidade dos dados.</dd>
+                            </div>
+                            <div>
+                                <dt>Governação e revisão humana ou proteção de dados</dt>
+                                <dd>Desenhado para revisão agregada ou adequada ao papel, com interpretação humana de exceções e sem alegar tomada de decisão automática.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Protótipos de dashboard que apoiam revisão programática recorrente e fornecem uma base para tomada de decisão.</dd>
+                            </div>
+                            <div>
+                                <dt>O que demonstra</dt>
+                                <dd>Como a visualização de dados pode ajudar equipas a ver o estado de programas e a estruturar conversas operacionais.</dd>
+                            </div>
+                            <div>
+                                <dt>Transferibilidade</dt>
+                                <dd>O padrão de monitorização pode ser reutilizado noutros programas preventivos, de saúde populacional ou de percursos assistenciais.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Dashboards</span>
+                            <span>Rastreios</span>
+                            <span>Dados</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Vigilância</span>
-                        <span>Automação</span>
-                        <span>Reporte</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">04</span>
-                        <p class="project-meta">Digitalização administrativa</p>
-                    </div>
-                    <h4>Registos Sanitários de Piscinas</h4>
-                    <p class="project-summary">Transição de processos em papel para registos digitais mais simples de consultar e auditar.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Requisitos administrativos, rastreabilidade, adoção pelas equipas e clareza documental.</dd>
+                    </article>
+                </div>
+            </section>
+
+            <section class="additional-work" aria-labelledby="additional-work-heading">
+                <div class="section-heading">
+                    <p class="eyebrow">Portefólio de apoio</p>
+                    <h3 id="additional-work-heading">Trabalho Aplicado Adicional</h3>
+                    <p>Cartões secundários mais curtos preservam outro material de saúde pública e transformação digital em termos seguros e agregados.</p>
+                </div>
+                <div class="project-index supporting-projects-grid" aria-label="Trabalho aplicado adicional">
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A1</span>
+                            <p class="project-meta">Planeamento em saúde pública</p>
                         </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Fluxo de trabalho mais transparente e menor fricção na gestão dos registos.</dd>
+                        <h4>Diagnóstico de Situação de Saúde e Planeamento Municipal</h4>
+                        <p class="project-summary">Organização de evidência populacional para apoiar prioridades locais e decisões de planeamento.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Foco</dt>
+                                <dd>Indicadores, território, necessidades de saúde e leitura operacional para decisão pública.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Base de trabalho clara para discussão local, sem expor dados pessoais ou informação sensível.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Saúde pública</span>
+                            <span>Planeamento</span>
+                            <span>Indicadores</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>GovTech</span>
-                        <span>Registos</span>
-                        <span>Processos</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">05</span>
-                        <p class="project-meta">Percursos assistenciais</p>
-                    </div>
-                    <h4>ICTUSnet e Coordenação de Percursos</h4>
-                    <p class="project-summary">Trabalho colaborativo em torno de percursos de AVC, informação partilhada e coordenação entre equipas.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Interoperabilidade, tempos de resposta, qualidade dos dados e alinhamento entre stakeholders.</dd>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A2</span>
+                            <p class="project-meta">Vigilância e reporte</p>
                         </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Melhor enquadramento comum para decisões clínicas, operacionais e tecnológicas.</dd>
+                        <h4>Boletins de Vigilância Digitais</h4>
+                        <p class="project-summary">Fluxos repetíveis de boletins que apoiam comunicação em saúde pública e reporte agregado recorrente.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Foco</dt>
+                                <dd>Preparação de dados, rotinas repetíveis e clareza de comunicação em saúde pública.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Publicações periódicas mais consistentes e menor dependência de formatação avulsa.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Vigilância</span>
+                            <span>Automação</span>
+                            <span>Reporte</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Percursos</span>
-                        <span>Interoperabilidade</span>
-                        <span>Colaboração</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">06</span>
-                        <p class="project-meta">IA e ciência de dados aplicada</p>
-                    </div>
-                    <h4>Protótipos com IA, NLP e GIS</h4>
-                    <p class="project-summary">Exploração prática de IA, processamento de texto e análise geográfica em problemas de saúde pública.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Viabilidade técnica, utilidade operacional, privacidade, governação e revisão humana.</dd>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A3</span>
+                            <p class="project-meta">Digitalização administrativa</p>
                         </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Critérios mais claros para decidir que ideias devem passar de protótipo a implementação.</dd>
+                        <h4>Registos Sanitários de Piscinas</h4>
+                        <p class="project-summary">Estruturas de registo digital que tornam processos administrativos em saúde mais fáceis de consultar, rastrear e rever.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Foco</dt>
+                                <dd>Requisitos administrativos, rastreabilidade, uso pelas equipas e clareza documental.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Fluxo de trabalho mais transparente e menor fricção na gestão dos registos.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>GovTech</span>
+                            <span>Registos</span>
+                            <span>Processos</span>
                         </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>IA</span>
-                        <span>NLP</span>
-                        <span>GIS</span>
-                        <span>Governação</span>
-                    </div>
-                </article>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A4</span>
+                            <p class="project-meta">Percursos assistenciais</p>
+                        </div>
+                        <h4>ICTUSnet e Coordenação de Percursos</h4>
+                        <p class="project-summary">Trabalho colaborativo em torno de percursos de AVC, informação partilhada e coordenação entre equipas.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Foco</dt>
+                                <dd>Interoperabilidade, tempos de resposta, qualidade dos dados e alinhamento entre stakeholders.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Melhor enquadramento comum para decisões clínicas, operacionais e tecnológicas.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>Percursos</span>
+                            <span>Interoperabilidade</span>
+                            <span>Colaboração</span>
+                        </div>
+                    </article>
+                    <article class="project-card supporting-project-card">
+                        <div class="project-card__head">
+                            <span class="project-number">A5</span>
+                            <p class="project-meta">IA e ciência de dados aplicada</p>
+                        </div>
+                        <h4>Protótipos com IA, NLP e GIS</h4>
+                        <p class="project-summary">Protótipos práticos que exploram IA, processamento de texto e análise geográfica em problemas de saúde pública.</p>
+                        <dl class="project-facts">
+                            <div>
+                                <dt>Foco</dt>
+                                <dd>Viabilidade técnica, utilidade operacional, privacidade, governação e revisão humana.</dd>
+                            </div>
+                            <div>
+                                <dt>Resultado</dt>
+                                <dd>Critérios mais claros para decidir que ideias devem passar de protótipo a passos seguintes responsáveis.</dd>
+                            </div>
+                        </dl>
+                        <div class="project-tags">
+                            <span>IA</span>
+                            <span>NLP</span>
+                            <span>GIS</span>
+                            <span>Governação</span>
+                        </div>
+                    </article>
+                </div>
             </section>
 
             <section class="projects-method">
                 <h3>Como estes projetos são trabalhados</h3>
                 <div class="method-grid">
                     <div><h4>Clareza da decisão</h4><p>Começar por quem decide, com que cadência e que indicador muda a ação.</p></div>
-                    <div><h4>Manutenção realista</h4><p>Preferir soluções que as equipas conseguem atualizar, explicar e auditar.</p></div>
+                    <div><h4>Manutenção realista</h4><p>Preferir soluções que as equipas conseguem atualizar, explicar e auditar ao longo do tempo.</p></div>
                     <div><h4>Governação visível</h4><p>Tratar privacidade, rastreabilidade e responsabilidade humana como requisitos de desenho.</p></div>
                 </div>
             </section>


### PR DESCRIPTION
### Motivation
- Create a clear visual and semantic hierarchy on the projects pages so three prominent case studies are discoverable by stable anchors and distinguished from supporting projects.
- Keep all content public, aggregated and careful with wording (prototype / demonstrator / supports / helps structure / provides a basis for decision-making) and avoid claims about production or adoption.

### Description
- Added a new `Featured Work` / `Trabalho em Destaque` section to `en/projects.html` and `pt/projetos.html` containing three anchored case-study articles with IDs `episignal`, `uls-pls-digital` and `screening-dashboards`, each following the requested case-study structure (Problem, Context, My role, Methods/tools, Governance and human review or data protection, Output, What it demonstrates, Transferability). 
- Moved the existing projects into an `Additional Applied Work` / `Trabalho Aplicado Adicional` section using lighter `supporting-project-card` styling so supporting items (Digital Surveillance Bulletins / Boletins de Vigilância Digitais; Sanitary Pool Records / Registos Sanitários de Piscinas; ICTUSnet / ICTUSnet e Coordenação de Percursos; AI/NLP/GIS prototypes / Protótipos com IA, NLP e GIS; and planning material) remain public and aggregate. 
- Added CSS in `assets/css/styles.css` to implement visual hierarchy and responsive grids with `.featured-projects-grid`, `.project-card.featured-project-card`, `.project-card.supporting-project-card`, `.case-study-facts`, and dark-mode variants, and updated the stylesheet query string used by the pages to `?v=20260605-featured-projects`.
- Tidy wording adjustments in both language pages to prefer longer-lived maintenance phrasing and to avoid implying production/adoption or quantified impact.

### Testing
- Ran `git diff --check` and found no whitespace or syntax issues (success). 
- Executed a Python `HTMLParser` script to verify both pages contain the three required anchors, have no duplicate IDs and the expected article count (success for both `en/projects.html` and `pt/projetos.html`).
- Performed local HTTP HEAD requests for both pages to confirm they are served (success) and captured a Playwright screenshot of the English page to exercise the layout and new styles (screenshot created successfully).
- Verified CSS updates and responsive grid behavior by inspecting the stylesheet additions and running responsive layout checks (manual automated checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a8407c908328b91372c63ead6dae)