### PR TITLE
Reframe research pages and add selected publications with noscript fallback

### DIFF
--- a/en/publications.html
+++ b/en/publications.html
@@ -99,11 +99,34 @@
                 <p>This list is regularly updated from the ORCID profile and brings together publicly registered research output.</p>
             </section>
 
+            <section class="selected-publications" aria-labelledby="selected-publications-heading">
+                <h3 id="selected-publications-heading">Selected publications supporting this work</h3>
+                <p>These selected publications connect the research areas above to screening analytics, ERIMS and emergency response, data management, and process mining.</p>
+                <ul class="publications-list">
+                    <li><strong>Population-Based Cancer Screening analysis in Northern Portugal Using Process Mining</strong> (2026) <em>Journal of Cancer Policy</em> <a href="https://doi.org/10.1016/j.jcpo.2026.100702" target="_blank" rel="noopener">Link</a></li>
+                    <li><strong>Enhancing information for action: A strategic tool for strengthening public health emergency management systems</strong> (2025) <em>International Journal of Medical Informatics</em> <a href="https://doi.org/10.1016/j.ijmedinf.2025.105791" target="_blank" rel="noopener">Link</a></li>
+                    <li><strong>Managing Data in Screening Programs: Challenges and Solutions</strong> (2025) <em>Acta Médica Portuguesa</em> <a href="https://doi.org/10.20344/amp.23363" target="_blank" rel="noopener">Link</a></li>
+                    <li><strong>Optimizing Colorectal Screening in Portugal with Process Mining</strong> (2024) <em>European Journal of Public Health</em> <a href="https://doi.org/10.1093/eurpub/ckae144.2110" target="_blank" rel="noopener">Link</a></li>
+                </ul>
+            </section>
+
             <section id="publications-content" class="publications-section">
                 <!-- Publications content will be loaded here -->
                 <div class="loading-message">
                     <p>Loading publications...</p>
                 </div>
+                <noscript>
+                    <div class="publications-fallback">
+                        <p>JavaScript is disabled, so the full generated publication list cannot be loaded here. Please consult the <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener">ORCID profile</a> for the complete list.</p>
+                        <h3>Selected publications supporting this work</h3>
+                        <ul class="publications-list">
+                            <li><strong>Population-Based Cancer Screening analysis in Northern Portugal Using Process Mining</strong> (2026) <em>Journal of Cancer Policy</em> <a href="https://doi.org/10.1016/j.jcpo.2026.100702" target="_blank" rel="noopener">Link</a></li>
+                            <li><strong>Enhancing information for action: A strategic tool for strengthening public health emergency management systems</strong> (2025) <em>International Journal of Medical Informatics</em> <a href="https://doi.org/10.1016/j.ijmedinf.2025.105791" target="_blank" rel="noopener">Link</a></li>
+                            <li><strong>Managing Data in Screening Programs: Challenges and Solutions</strong> (2025) <em>Acta Médica Portuguesa</em> <a href="https://doi.org/10.20344/amp.23363" target="_blank" rel="noopener">Link</a></li>
+                            <li><strong>Optimizing Colorectal Screening in Portugal with Process Mining</strong> (2024) <em>European Journal of Public Health</em> <a href="https://doi.org/10.1093/eurpub/ckae144.2110" target="_blank" rel="noopener">Link</a></li>
+                        </ul>
+                    </div>
+                </noscript>
             </section>
 
             <section class="additional-resources">

--- a/en/research.html
+++ b/en/research.html
@@ -86,11 +86,11 @@
         <article class="page-content">
             <header class="page-header">
                 <h2>Research Interests</h2>
-                <p class="lead">Advancing healthcare through digital innovation and evidence-based public health strategies</p>
+                <p class="lead">Research at the intersection of public health intelligence, digital health systems, and operational analytics</p>
             </header>
 
             <section class="research-overview">
-                <p>The research focuses on the intersection of digital technology and healthcare delivery, with particular emphasis on public health systems and data-driven decision making. Doctoral work in Health Data Science explores applications of digital technologies in health operations and outcomes management.</p>
+                <p>The research focuses on how digital health, health information systems, and analytics can support public health action across the portfolio: detecting public health events and emergencies, planning services around territorial and population needs, and improving programmes and operations through screening analytics, process mining, and dashboards.</p>
             </section>
 
             <section class="research-areas">
@@ -98,67 +98,67 @@
                 
                 <div class="research-grid">
                     <article class="research-item">
-                        <h4>Digital Health Systems</h4>
-                        <p>Investigating the implementation and optimization of digital health technologies in clinical and public health settings. Focus on system integration, user experience, and measurable impact on healthcare delivery quality and efficiency.</p>
+                        <h4>Screening and Process Mining</h4>
+                        <p>Studying population-based screening programmes through pathway analysis, data quality assessment, and process mining methods. This work focuses on understanding programme flows, identifying bottlenecks, and supporting operational improvement in screening services.</p>
+                        <ul class="research-keywords">
+                            <li>Population-Based Screening</li>
+                            <li>Process Mining</li>
+                            <li>Programme Pathway Analytics</li>
+                            <li>Operational Dashboards</li>
+                        </ul>
+                    </article>
+
+                    <article class="research-item">
+                        <h4>Public Health Emergency Information Systems / ERIMS</h4>
+                        <p>Exploring information systems that support public health emergency preparedness, response, and management, including ERIMS-related assessment and information-for-action approaches for surveillance and emergency coordination.</p>
+                        <ul class="research-keywords">
+                            <li>Emergency Information Systems</li>
+                            <li>ERIMS</li>
+                            <li>Public Health Surveillance</li>
+                            <li>Information for Action</li>
+                        </ul>
+                    </article>
+
+                    <article class="research-item">
+                        <h4>Digital Health and Health Information Systems</h4>
+                        <p>Examining the design, implementation, and governance of digital health and health information systems that support public health management, service planning, and clinical or operational decision-making.</p>
                         <ul class="research-keywords">
                             <li>Health Information Systems</li>
-                            <li>Electronic Health Records</li>
-                            <li>Telemedicine Platforms</li>
                             <li>Digital Health Workflows</li>
+                            <li>Data Governance</li>
+                            <li>Interoperability</li>
                         </ul>
                     </article>
 
                     <article class="research-item">
-                        <h4>Screening Programs</h4>
-                        <p>Developing and evaluating evidence-based screening programs for population health management. Research includes program design, implementation strategies, and effectiveness assessment using health data analytics.</p>
+                        <h4>Population Health Analytics</h4>
+                        <p>Using real-world data, territorial intelligence, and population health methods to describe needs, monitor patterns, and inform planning across public health and health service contexts.</p>
                         <ul class="research-keywords">
-                            <li>Population Health Screening</li>
-                            <li>Program Effectiveness</li>
-                            <li>Health Outcomes Research</li>
-                            <li>Risk Stratification</li>
-                        </ul>
-                    </article>
-
-                    <article class="research-item">
-                        <h4>Health Information Systems</h4>
-                        <p>Exploring the design, implementation, and optimization of health information systems that support clinical decision-making and health system management. Focus on interoperability, data quality, and system usability.</p>
-                        <ul class="research-keywords">
-                            <li>Health Data Integration</li>
-                            <li>System Interoperability</li>
-                            <li>Data Quality Management</li>
-                            <li>Clinical Decision Support</li>
-                        </ul>
-                    </article>
-
-                    <article class="research-item">
-                        <h4>Data Visualization & Business Intelligence</h4>
-                        <p>Advancing the use of data visualization and business intelligence tools in healthcare to improve decision-making, operational efficiency, and health outcomes. Research includes dashboard design, analytics implementation, and user adoption.</p>
-                        <ul class="research-keywords">
-                            <li>Healthcare Dashboards</li>
-                            <li>Performance Analytics</li>
-                            <li>Visual Analytics</li>
-                            <li>Decision Support Systems</li>
+                            <li>Population Needs Assessment</li>
+                            <li>Territorial Intelligence</li>
+                            <li>Real-World Data</li>
+                            <li>Risk and Service Planning</li>
                         </ul>
                     </article>
                 </div>
             </section>
 
             <section class="current-projects">
-                <h3>Current Research Focus</h3>
+                <h3>Connection to the Portfolio</h3>
                 <div class="projects-list">
                     <article class="project-item">
-                        <h4>PhD Research: Health Data Science</h4>
-                        <p>Doctoral research in progress on advanced analytics and machine learning applications in public health systems, with focus on population health management and healthcare system optimization.</p>
+                        <h4>Detect</h4>
+                        <p>Surveillance, public health emergency information, and ERIMS-related work support earlier detection, shared situational awareness, and more structured emergency response information.</p>
                     </article>
 
                     <article class="project-item">
-                        <h4>Digital Health Implementation</h4>
-                        <p>Research on implementation of digital health solutions in Portuguese healthcare settings, with emphasis on impact measurement, user adoption, and system integration challenges.</p>
+                        <h4>Plan</h4>
+                        <p>Territorial intelligence, population needs assessment, and health information systems support service planning and priority-setting grounded in available data.</p>
                     </article>
 
                     <article class="project-item">
-                        <h4>WHO/Europe Consultation</h4>
-                        <p>Contribution to international initiatives through consultancy work with WHO/Europe, focusing on digital health policy development and implementation strategies across European health systems.</p>
+                        <h4>Improve</h4>
+                        <p>Screening analytics, process mining, and operational dashboards support continuous programme review, pathway visibility, and practical improvement work.</p>
                     </article>
                 </div>
             </section>

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -87,11 +87,11 @@
         <article class="page-content">
             <header class="page-header">
                 <h2>Interesses de Investigação</h2>
-                <p class="lead">Avançar os cuidados de saúde através da inovação digital e estratégias de saúde pública baseadas em evidência</p>
+                <p class="lead">Investigação na interseção entre inteligência em saúde pública, sistemas digitais de saúde e análise operacional</p>
             </header>
 
             <section class="research-overview">
-                <p>A investigação centra-se na interseção entre tecnologia digital e prestação de cuidados de saúde, com particular ênfase em sistemas de saúde pública e tomada de decisões baseada em dados. O trabalho doutoral em Ciência de Dados em Saúde explora aplicações de tecnologias digitais nas operações de saúde e na gestão de resultados.</p>
+                <p>A investigação centra-se na forma como a saúde digital, os sistemas de informação em saúde e a análise de dados podem apoiar a ação em saúde pública ao longo do portefólio: detetar eventos e emergências de saúde pública, planear serviços de acordo com necessidades territoriais e populacionais, e melhorar programas e operações através de análise de rastreios, process mining e dashboards.</p>
             </section>
 
             <section class="research-areas">
@@ -99,67 +99,67 @@
                 
                 <div class="research-grid">
                     <article class="research-item">
-                        <h4>Sistemas de Saúde Digital</h4>
-                        <p>Investigação da implementação e otimização de tecnologias de saúde digital em contextos clínicos e de saúde pública. Foco na integração de sistemas, experiência do utilizador e impacto mensurável na qualidade e eficiência da prestação de cuidados de saúde.</p>
+                        <h4>Rastreio e Process Mining</h4>
+                        <p>Estudo de programas de rastreio de base populacional através da análise de percursos, avaliação da qualidade dos dados e métodos de process mining. Este trabalho foca-se na compreensão dos fluxos dos programas, na identificação de constrangimentos e no apoio à melhoria operacional dos serviços de rastreio.</p>
+                        <ul class="research-keywords">
+                            <li>Rastreio de Base Populacional</li>
+                            <li>Process Mining</li>
+                            <li>Análise de Percursos de Programas</li>
+                            <li>Dashboards Operacionais</li>
+                        </ul>
+                    </article>
+
+                    <article class="research-item">
+                        <h4>Sistemas de Informação para Emergências de Saúde Pública / ERIMS</h4>
+                        <p>Exploração de sistemas de informação que apoiam a preparação, resposta e gestão de emergências de saúde pública, incluindo avaliação relacionada com ERIMS e abordagens de informação para a ação em vigilância e coordenação de emergências.</p>
+                        <ul class="research-keywords">
+                            <li>Sistemas de Informação de Emergência</li>
+                            <li>ERIMS</li>
+                            <li>Vigilância em Saúde Pública</li>
+                            <li>Informação para a Ação</li>
+                        </ul>
+                    </article>
+
+                    <article class="research-item">
+                        <h4>Saúde Digital e Sistemas de Informação em Saúde</h4>
+                        <p>Análise do desenho, implementação e governação de soluções de saúde digital e sistemas de informação em saúde que apoiam a gestão em saúde pública, o planeamento de serviços e a decisão clínica ou operacional.</p>
                         <ul class="research-keywords">
                             <li>Sistemas de Informação em Saúde</li>
-                            <li>Registos Eletrónicos de Saúde</li>
-                            <li>Plataformas de Telemedicina</li>
                             <li>Fluxos de Trabalho de Saúde Digital</li>
+                            <li>Governação de Dados</li>
+                            <li>Interoperabilidade</li>
                         </ul>
                     </article>
 
                     <article class="research-item">
-                        <h4>Programas de Rastreio</h4>
-                        <p>Desenvolvimento e avaliação de programas de rastreio baseados em evidência para gestão da saúde populacional. A investigação inclui design de programas, estratégias de implementação e avaliação da eficácia usando análise de dados de saúde.</p>
+                        <h4>Análise de Saúde Populacional</h4>
+                        <p>Utilização de dados do mundo real, inteligência territorial e métodos de saúde populacional para descrever necessidades, monitorizar padrões e informar o planeamento em contextos de saúde pública e de serviços de saúde.</p>
                         <ul class="research-keywords">
-                            <li>Rastreio de Saúde Populacional</li>
-                            <li>Eficácia de Programas</li>
-                            <li>Investigação de Resultados em Saúde</li>
-                            <li>Estratificação de Risco</li>
-                        </ul>
-                    </article>
-
-                    <article class="research-item">
-                        <h4>Sistemas de Informação em Saúde</h4>
-                        <p>Exploração do design, implementação e otimização de sistemas de informação em saúde que apoiam a tomada de decisões clínicas e a gestão do sistema de saúde. Foco na interoperabilidade, qualidade dos dados e usabilidade do sistema.</p>
-                        <ul class="research-keywords">
-                            <li>Integração de Dados de Saúde</li>
-                            <li>Interoperabilidade de Sistemas</li>
-                            <li>Gestão da Qualidade de Dados</li>
-                            <li>Apoio à Decisão Clínica</li>
-                        </ul>
-                    </article>
-
-                    <article class="research-item">
-                        <h4>Visualização de Dados & Business Intelligence</h4>
-                        <p>Avanço do uso de ferramentas de visualização de dados e business intelligence em cuidados de saúde para melhorar a tomada de decisões, eficiência operacional e resultados em saúde. A investigação inclui design de dashboards, implementação de análises e adoção pelo utilizador.</p>
-                        <ul class="research-keywords">
-                            <li>Dashboards de Saúde</li>
-                            <li>Análise de Performance</li>
-                            <li>Análise Visual</li>
-                            <li>Sistemas de Apoio à Decisão</li>
+                            <li>Avaliação de Necessidades Populacionais</li>
+                            <li>Inteligência Territorial</li>
+                            <li>Dados do Mundo Real</li>
+                            <li>Planeamento de Risco e Serviços</li>
                         </ul>
                     </article>
                 </div>
             </section>
 
             <section class="current-projects">
-                <h3>Foco de Investigação Atual</h3>
+                <h3>Ligação ao Portefólio</h3>
                 <div class="projects-list">
                     <article class="project-item">
-                        <h4>Investigação de Doutoramento: Ciência de Dados em Saúde</h4>
-                        <p>Investigação doutoral em desenvolvimento sobre análises avançadas e aplicações de machine learning em sistemas de saúde pública, com foco na gestão da saúde populacional e na otimização do sistema de saúde.</p>
+                        <h4>Detectar</h4>
+                        <p>A vigilância, a informação para emergências de saúde pública e o trabalho relacionado com ERIMS apoiam deteção mais precoce, consciência situacional partilhada e informação mais estruturada para a resposta a emergências.</p>
                     </article>
 
                     <article class="project-item">
-                        <h4>Implementação de Saúde Digital</h4>
-                        <p>Investigação sobre implementação de soluções de saúde digital em contextos de cuidados de saúde portugueses, com ênfase na medição de impacto, adoção pelo utilizador e desafios de integração de sistemas.</p>
+                        <h4>Planear</h4>
+                        <p>A inteligência territorial, a avaliação de necessidades populacionais e os sistemas de informação em saúde apoiam o planeamento de serviços e a definição de prioridades com base nos dados disponíveis.</p>
                     </article>
 
                     <article class="project-item">
-                        <h4>Consultoria OMS/Europa</h4>
-                        <p>Contributo para iniciativas internacionais através de consultoria para a OMS/Europa, com foco no desenvolvimento de políticas de saúde digital e estratégias de implementação em sistemas de saúde europeus.</p>
+                        <h4>Melhorar</h4>
+                        <p>A análise de rastreios, o process mining e os dashboards operacionais apoiam a revisão contínua de programas, a visibilidade dos percursos e o trabalho prático de melhoria.</p>
                     </article>
                 </div>
             </section>

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -100,11 +100,34 @@
                 <p>Esta lista é atualizada regularmente a partir do perfil ORCID e reúne a produção científica registada publicamente.</p>
             </section>
 
+            <section class="selected-publications" aria-labelledby="selected-publications-heading">
+                <h3 id="selected-publications-heading">Publicações selecionadas que apoiam este trabalho</h3>
+                <p>Estas publicações selecionadas ligam as áreas de investigação à análise de rastreios, ERIMS e resposta a emergências, gestão de dados e process mining.</p>
+                <ul class="publications-list">
+                    <li><strong>Population-Based Cancer Screening analysis in Northern Portugal Using Process Mining</strong> (2026) <em>Journal of Cancer Policy</em> <a href="https://doi.org/10.1016/j.jcpo.2026.100702" target="_blank" rel="noopener">Link</a></li>
+                    <li><strong>Enhancing information for action: A strategic tool for strengthening public health emergency management systems</strong> (2025) <em>International Journal of Medical Informatics</em> <a href="https://doi.org/10.1016/j.ijmedinf.2025.105791" target="_blank" rel="noopener">Link</a></li>
+                    <li><strong>Managing Data in Screening Programs: Challenges and Solutions</strong> (2025) <em>Acta Médica Portuguesa</em> <a href="https://doi.org/10.20344/amp.23363" target="_blank" rel="noopener">Link</a></li>
+                    <li><strong>Optimizing Colorectal Screening in Portugal with Process Mining</strong> (2024) <em>European Journal of Public Health</em> <a href="https://doi.org/10.1093/eurpub/ckae144.2110" target="_blank" rel="noopener">Link</a></li>
+                </ul>
+            </section>
+
             <section id="publications-content" class="publications-section">
                 <!-- Publications content will be loaded here -->
                 <div class="loading-message">
                     <p>A carregar publicações...</p>
                 </div>
+                <noscript>
+                    <div class="publications-fallback">
+                        <p>O JavaScript está desativado, pelo que a lista completa gerada de publicações não pode ser carregada aqui. Consulte o <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener">perfil ORCID</a> para a lista completa.</p>
+                        <h3>Publicações selecionadas que apoiam este trabalho</h3>
+                        <ul class="publications-list">
+                            <li><strong>Population-Based Cancer Screening analysis in Northern Portugal Using Process Mining</strong> (2026) <em>Journal of Cancer Policy</em> <a href="https://doi.org/10.1016/j.jcpo.2026.100702" target="_blank" rel="noopener">Link</a></li>
+                            <li><strong>Enhancing information for action: A strategic tool for strengthening public health emergency management systems</strong> (2025) <em>International Journal of Medical Informatics</em> <a href="https://doi.org/10.1016/j.ijmedinf.2025.105791" target="_blank" rel="noopener">Link</a></li>
+                            <li><strong>Managing Data in Screening Programs: Challenges and Solutions</strong> (2025) <em>Acta Médica Portuguesa</em> <a href="https://doi.org/10.20344/amp.23363" target="_blank" rel="noopener">Link</a></li>
+                            <li><strong>Optimizing Colorectal Screening in Portugal with Process Mining</strong> (2024) <em>European Journal of Public Health</em> <a href="https://doi.org/10.1093/eurpub/ckae144.2110" target="_blank" rel="noopener">Link</a></li>
+                        </ul>
+                    </div>
+                </noscript>
             </section>
 
             <section class="additional-resources">


### PR DESCRIPTION
### Motivation
- Align the English and Portuguese research pages to four focused areas: screening/process mining, public health emergency information systems (ERIMS), digital health/HIS, and population health analytics. 
- Connect those research areas to the existing portfolio structure (`Detect`, `Plan`, `Improve`) so visitors can see practical lines of work. 
- Surface a short, curated list of publications that directly support the above work while preserving the existing ORCID-driven publication list and providing a non-JS fallback. 

### Description
- Rewrote the lead and overview in `en/research.html` and `pt/investigacao.html` to reframe the research focus and removed/softened generic claims about measurable impact. 
- Replaced the previous broad research-area blocks with four focused items: `Screening and Process Mining`, `Public Health Emergency Information Systems / ERIMS`, `Digital Health and Health Information Systems`, and `Population Health Analytics` in both `en/research.html` and `pt/investigacao.html`. 
- Added a `Connection to the Portfolio` (`Detect` / `Plan` / `Improve`) section in both research pages to map research activities to the portfolio. 
- Inserted a static `Selected publications supporting this work` section into `en/publications.html` and `pt/publicacoes.html` using publications already present in `publications/publications_en.html` and `publications/publications_pt.html`. 
- Added a `<noscript>` non-JavaScript fallback to both publications pages that links to ORCID and includes the same selected list, while keeping the JavaScript fetch that loads the full ORCID-generated list from `/publications/publications_*.html`. 

### Testing
- Ran a Python `HTMLParser` smoke test to ensure the updated HTML files parse and to verify the selected publication titles are present in `publications/publications_en.html` and `publications/publications_pt.html`; the check succeeded. 
- Launched a local `python3 -m http.server` and used `npx playwright` to capture screenshots of `/en/research.html` and `/en/publications.html`; the screenshots command completed successfully after installing Playwright browsers and necessary deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a84df3548328b28449d0fc02795c)