### PR TITLE
Add bilingual speaking and training pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -102,6 +102,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">

--- a/en/about.html
+++ b/en/about.html
@@ -120,6 +120,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/contact.html
+++ b/en/contact.html
@@ -60,6 +60,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html" aria-current="page">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/experience.html
+++ b/en/experience.html
@@ -58,6 +58,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html" aria-current="page">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/index.html
+++ b/en/index.html
@@ -101,6 +101,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/legal.html
+++ b/en/legal.html
@@ -26,6 +26,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/projects.html
+++ b/en/projects.html
@@ -44,6 +44,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
         <a href="/en/projects.html" aria-current="page">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle dark/light theme">

--- a/en/publications.html
+++ b/en/publications.html
@@ -58,6 +58,7 @@
         <a href="/en/research.html">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html" aria-current="page">Publications</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/research.html
+++ b/en/research.html
@@ -58,6 +58,7 @@
         <a href="/en/research.html" aria-current="page">Research</a>
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/publications.html">Publications</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/en/speaking-training.html
+++ b/en/speaking-training.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Speaking & Training - Hugo Monteiro | Public Health Intelligence and Digital Health</title>
+    <meta name="description" content="Speaking, workshops, training, and advisory formats for institutions working on public health intelligence, digital transformation, screening analytics, and health information systems.">
+    <meta name="author" content="Hugo Monteiro">
+    <link rel="canonical" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Speaking & Training - Hugo Monteiro">
+    <meta property="og:description" content="Topics and formats for institutions working on public health intelligence, digital transformation, screening analytics, and health information systems.">
+    <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta property="og:url" content="https://www.hfmonteiro.com/en/speaking-training.html">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:locale:alternate" content="pt_PT">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Speaking & Training - Hugo Monteiro">
+    <meta name="twitter:description" content="Topics and formats for public health intelligence, digital transformation, screening analytics, and health information systems.">
+    <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
+    <link rel="icon" type="image/png" href="/assets/img/favicon.png">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-v2projects" as="style">
+    <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-v2projects">
+</head>
+<body>
+    <a href="#main" class="skip-link">Skip to main content</a>
+    <header>
+        <h1>Hugo Monteiro</h1>
+        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+    </header>
+
+    <nav role="navigation" aria-label="Main navigation">
+        <a href="/en/">Home</a>
+        <a href="/en/about.html">About</a>
+        <a href="/en/research.html">Research</a>
+        <a href="/en/experience.html">Experience</a>
+        <a href="/en/projects.html">Projects</a>
+        <a href="/en/speaking-training.html" aria-current="page">Speaking & Training</a>
+        <a href="/en/publications.html">Publications</a>
+        <a href="/en/contact.html">Contact</a>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
+            <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+            <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+
+        <div class="lang-switcher" role="group" aria-label="Language switcher">
+            <a href="/en/speaking-training.html" rel="alternate" hreflang="en" class="lang-active" aria-current="true" aria-label="Selected language">EN</a> |
+            <a href="/pt/formacao-palestras.html" rel="alternate" hreflang="pt-PT">PT</a>
+        </div>
+    </nav>
+
+    <main role="main" id="main">
+        <article class="page-content">
+            <header class="page-header">
+                <h2>Speaking & Training</h2>
+                <p class="lead">Topics for institutions working on public health intelligence, digital transformation, screening analytics, and health information systems.</p>
+            </header>
+
+            <section aria-labelledby="topics-heading">
+                <h3 id="topics-heading">Topics</h3>
+                <ul class="achievements">
+                    <li>Public health intelligence systems.</li>
+                    <li>From surveillance data to actionable signals.</li>
+                    <li>Dashboards that actually change decisions.</li>
+                    <li>Screening programme analytics and process mining.</li>
+                    <li>Local health planning and territorial intelligence.</li>
+                    <li>Health information systems for emergency preparedness.</li>
+                    <li>Responsible AI workflows in public health.</li>
+                </ul>
+            </section>
+
+            <section aria-labelledby="formats-heading">
+                <h3 id="formats-heading">Suitable formats</h3>
+                <div class="opportunities-grid">
+                    <div class="opportunity-item"><h4>Keynote or invited talk</h4><p>Strategic sessions for conferences, institutional meetings, or leadership audiences.</p></div>
+                    <div class="opportunity-item"><h4>Workshop</h4><p>Hands-on formats for teams translating data, processes, and governance into practical decisions.</p></div>
+                    <div class="opportunity-item"><h4>Training session</h4><p>Structured learning for public health, analytics, digital transformation, and health information system teams.</p></div>
+                    <div class="opportunity-item"><h4>Project review or advisory session</h4><p>Focused review of ongoing dashboards, screening analytics, digital health, or AI governance initiatives.</p></div>
+                </div>
+            </section>
+
+            <section aria-labelledby="request-heading">
+                <h3 id="request-heading">Request guidance</h3>
+                <p>To discuss a speaking or training request, please <a href="/en/contact.html">contact me</a> with the preferred topic, format, audience, objectives, expected date or timeline, and whether the session is online, in-person, or hybrid.</p>
+            </section>
+        </article>
+    </main>
+
+    <footer>
+        <p>&copy; <span id="current-year"></span> Hugo Monteiro. 
+           <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener" class="orcid-link">ORCID</a> | 
+           <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener">LinkedIn</a> | 
+           <a href="/en/legal.html">Legal</a>
+        </p>
+    </footer>
+    <button id="scroll-to-top" class="scroll-to-top" aria-label="Scroll to top" title="Back to top">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"></polyline></svg>
+    </button>
+    <script src="/assets/js/script.js?v=20260521" defer></script>
+</body>
+</html>

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -59,6 +59,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html" aria-current="page">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/pt/experiencia.html
+++ b/pt/experiencia.html
@@ -59,6 +59,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html" aria-current="page">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/pt/formacao-palestras.html
+++ b/pt/formacao-palestras.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="pt-PT">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Palestras & Formação - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital</title>
+    <meta name="description" content="Palestras, workshops, formação e sessões de aconselhamento para instituições que trabalham em inteligência em saúde pública, transformação digital, análise de rastreios e sistemas de informação em saúde.">
+    <meta name="author" content="Hugo Monteiro">
+    <link rel="canonical" href="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Palestras & Formação - Hugo Monteiro">
+    <meta property="og:description" content="Tópicos e formatos para instituições que trabalham em inteligência em saúde pública, transformação digital, análise de rastreios e sistemas de informação em saúde.">
+    <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta property="og:url" content="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <meta property="og:locale" content="pt_PT">
+    <meta property="og:locale:alternate" content="en_US">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Palestras & Formação - Hugo Monteiro">
+    <meta name="twitter:description" content="Tópicos e formatos para inteligência em saúde pública, transformação digital, análise de rastreios e sistemas de informação em saúde.">
+    <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
+    <link rel="icon" type="image/png" href="/assets/img/favicon.png">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-v2projects" as="style">
+    <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-v2projects">
+</head>
+<body>
+    <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
+    <header>
+        <h1>Hugo Monteiro</h1>
+        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+    </header>
+
+    <nav role="navigation" aria-label="Navegação principal">
+        <a href="/pt/">Início</a>
+        <a href="/pt/sobre.html">Sobre</a>
+        <a href="/pt/investigacao.html">Investigação</a>
+        <a href="/pt/experiencia.html">Experiência</a>
+        <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html" aria-current="page">Palestras & Formação</a>
+        <a href="/pt/publicacoes.html">Publicações</a>
+        <a href="/pt/contacto.html">Contacto</a>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
+            <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+            <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+
+        <div class="lang-switcher" role="group" aria-label="Seletor de idioma">
+            <a href="/en/speaking-training.html" rel="alternate" hreflang="en">EN</a> |
+            <a href="/pt/formacao-palestras.html" rel="alternate" hreflang="pt-PT" class="lang-active" aria-current="true" aria-label="Idioma selecionado">PT</a>
+        </div>
+    </nav>
+
+    <main role="main" id="main">
+        <article class="page-content">
+            <header class="page-header">
+                <h2>Palestras & Formação</h2>
+                <p class="lead">Tópicos para instituições que trabalham em inteligência em saúde pública, transformação digital, análise de rastreios e sistemas de informação em saúde.</p>
+            </header>
+
+            <section aria-labelledby="topics-heading">
+                <h3 id="topics-heading">Tópicos</h3>
+                <ul class="achievements">
+                    <li>Sistemas de inteligência em saúde pública.</li>
+                    <li>De dados de vigilância a sinais acionáveis.</li>
+                    <li>Dashboards que realmente mudam decisões.</li>
+                    <li>Análise de programas de rastreio e process mining.</li>
+                    <li>Planeamento local em saúde e inteligência territorial.</li>
+                    <li>Sistemas de informação em saúde para preparação e resposta a emergências.</li>
+                    <li>Fluxos de trabalho de IA responsável em saúde pública.</li>
+                </ul>
+            </section>
+
+            <section aria-labelledby="formats-heading">
+                <h3 id="formats-heading">Formatos adequados</h3>
+                <div class="opportunities-grid">
+                    <div class="opportunity-item"><h4>Keynote ou palestra convidada</h4><p>Sessões estratégicas para conferências, reuniões institucionais ou audiências de liderança.</p></div>
+                    <div class="opportunity-item"><h4>Workshop</h4><p>Formatos práticos para equipas que traduzem dados, processos e governação em decisões concretas.</p></div>
+                    <div class="opportunity-item"><h4>Sessão de formação</h4><p>Aprendizagem estruturada para equipas de saúde pública, análise de dados, transformação digital e sistemas de informação em saúde.</p></div>
+                    <div class="opportunity-item"><h4>Revisão de projeto ou sessão de aconselhamento</h4><p>Revisão focada de dashboards, análise de rastreios, saúde digital ou iniciativas de governação de IA em curso.</p></div>
+                </div>
+            </section>
+
+            <section aria-labelledby="request-heading">
+                <h3 id="request-heading">Orientação para pedidos</h3>
+                <p>Para discutir um pedido de palestra ou formação, por favor <a href="/pt/contacto.html">entre em contacto</a> indicando o tópico, formato, público-alvo, objetivos, data ou calendário previsto, e se a sessão será online, presencial ou híbrida.</p>
+            </section>
+        </article>
+    </main>
+
+    <footer>
+        <p>&copy; <span id="current-year"></span> Hugo Monteiro. 
+           <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener" class="orcid-link">ORCID</a> | 
+           <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener">LinkedIn</a> | 
+           <a href="/pt/legal.html">Legal</a>
+        </p>
+    </footer>
+    <button id="scroll-to-top" class="scroll-to-top" aria-label="Voltar ao topo" title="Voltar ao topo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"></polyline></svg>
+    </button>
+    <script src="/assets/js/script.js?v=20260521" defer></script>
+</body>
+</html>

--- a/pt/index.html
+++ b/pt/index.html
@@ -88,6 +88,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -59,6 +59,7 @@
         <a href="/pt/investigacao.html" aria-current="page">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/pt/legal.html
+++ b/pt/legal.html
@@ -26,6 +26,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/pt/projetos.html
+++ b/pt/projetos.html
@@ -44,6 +44,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
         <a href="/pt/projetos.html" aria-current="page">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema claro/escuro" title="Alternar tema claro/escuro">

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -59,6 +59,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html" aria-current="page">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/pt/sobre.html
+++ b/pt/sobre.html
@@ -97,6 +97,7 @@
         <a href="/pt/investigacao.html">Investigação</a>
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/formacao-palestras.html">Palestras & Formação</a>
         <a href="/pt/publicacoes.html">Publicações</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/validate_site.js
+++ b/scripts/validate_site.js
@@ -48,6 +48,7 @@ const pages = [
   { file: 'en/research.html', lang: 'en', alternate: '/pt/investigacao.html' },
   { file: 'en/experience.html', lang: 'en', alternate: '/pt/experiencia.html' },
   { file: 'en/projects.html', lang: 'en', alternate: '/pt/projetos.html' },
+  { file: 'en/speaking-training.html', lang: 'en', alternate: '/pt/formacao-palestras.html' },
   { file: 'en/publications.html', lang: 'en', alternate: '/pt/publicacoes.html' },
   { file: 'en/contact.html', lang: 'en', alternate: '/pt/contacto.html' },
   { file: 'pt/index.html', lang: 'pt-PT', alternate: '/en/' },
@@ -55,6 +56,7 @@ const pages = [
   { file: 'pt/investigacao.html', lang: 'pt-PT', alternate: '/en/research.html' },
   { file: 'pt/experiencia.html', lang: 'pt-PT', alternate: '/en/experience.html' },
   { file: 'pt/projetos.html', lang: 'pt-PT', alternate: '/en/projects.html' },
+  { file: 'pt/formacao-palestras.html', lang: 'pt-PT', alternate: '/en/speaking-training.html' },
   { file: 'pt/publicacoes.html', lang: 'pt-PT', alternate: '/en/publications.html' },
   { file: 'pt/contacto.html', lang: 'pt-PT', alternate: '/en/contact.html' },
   { file: '404.html', lang: 'en', canonical: false, hreflang: false, sitemap: false }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -54,6 +54,15 @@
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
+
+  <url>
+    <loc>https://www.hfmonteiro.com/en/speaking-training.html</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html" />
+    <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html" />
+  </url>
   
   <url>
     <loc>https://www.hfmonteiro.com/en/publications.html</loc>
@@ -115,6 +124,15 @@
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
+
+  <url>
+    <loc>https://www.hfmonteiro.com/pt/formacao-palestras.html</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html" />
+    <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html" />
+  </url>
   
   <url>
     <loc>https://www.hfmonteiro.com/pt/publicacoes.html</loc>


### PR DESCRIPTION
### Motivation

- Add a new public-facing offering for speaking and training in both English and Portuguese and expose it from the existing site navigation. 
- Ensure the new pages are discoverable and validated with canonical/hreflang metadata, sitemap entries, and automated validation coverage.

### Description

- Added `en/speaking-training.html` and `pt/formacao-palestras.html` with the requested header, lead, topics list, "Suitable formats" section, and contact request guidance. 
- Inserted bilingual navigation links to the new pages across EN/PT templates so the pages appear in the main nav and language switcher. 
- Added canonical, `hreflang`, Open Graph and Twitter metadata to both pages and added sitemap entries in `sitemap.xml`. 
- Updated `scripts/validate_site.js` to include the new pages in site validation and adjusted internal page nav where needed.

### Testing

- Ran `git diff --check` and it reported no whitespace/merge errors. (OK)
- Executed `node scripts/validate_site.js` and all validation checks passed. (OK)
- Captured rendered page screenshots using `npx --yes playwright screenshot` for both new pages (screenshots saved). (OK)
- Attempted to run `SITE_BASE_URL=http://127.0.0.1:4173 npx --yes playwright test scripts/smoke_site.spec.js` but the run could not proceed because the repository does not include the `@playwright/test` dependency; the smoke test invocation therefore did not complete. (WARNING)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a86dfcb48328ba6c467d6b62a753)