### PR TITLE
Update health metadata, add Speaking & Training pages, and expand validation

### DIFF
--- a/en/contact.html
+++ b/en/contact.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Contact - Hugo Monteiro | Professional Channels and Collaboration</title>
-    <meta name="description" content="Professional channels for digital health collaboration, research, consulting, and event participation. Public profiles on LinkedIn and ORCID.">
+    <title>Contact - Hugo Monteiro | Public Health Intelligence and Digital Health Collaboration</title>
+    <meta name="description" content="Professional channels for collaboration on public health intelligence, digital health, health data science, screening analytics, surveillance, municipal health planning, health information systems, emergency information management, and BI in healthcare.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Contact Hugo Monteiro - Digital Health Specialist">
-    <meta property="og:description" content="Professional channels for digital health collaboration, research, consulting, and event participation.">
+    <meta property="og:title" content="Contact - Hugo Monteiro | Public Health Intelligence and Digital Health Collaboration">
+    <meta property="og:description" content="Professional channels for collaboration on public health intelligence, digital health, health data science, screening analytics, surveillance, municipal health planning, health information systems, emergency information management, and BI in healthcare.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/contact.html">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Contact Hugo Monteiro - Digital Health Specialist">
-    <meta name="twitter:description" content="Professional channels for digital health collaboration, research, consulting, and event participation.">
+    <meta name="twitter:title" content="Contact - Hugo Monteiro | Public Health Intelligence and Digital Health Collaboration">
+    <meta name="twitter:description" content="Professional channels for collaboration on public health intelligence, digital health, health data science, screening analytics, surveillance, municipal health planning, health information systems, emergency information management, and BI in healthcare.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -61,6 +61,7 @@
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
         <a href="/en/publications.html">Publications</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/contact.html" aria-current="page">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
@@ -79,7 +80,8 @@
         </button>
 
         <div class="lang-switcher" role="group" aria-label="Language switcher">
-            <a href="/en/contact.html" rel="alternate" hreflang="en" class="lang-active" aria-current="true" aria-label="Selected language">EN</a> |
+            <a href="/en/speaking-training.html">Speaking & Training</a>
+        <a href="/en/contact.html" rel="alternate" hreflang="en" class="lang-active" aria-current="true" aria-label="Selected language">EN</a> |
             <a href="/pt/contacto.html" rel="alternate" hreflang="pt-PT">PT</a>
         </div>
     </nav>

--- a/en/index.html
+++ b/en/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Hugo Monteiro - MD/MPH | Digital Health Specialist</title>
-    <meta name="description" content="Hugo Monteiro is a Portuguese MD/MPH dedicated to digital health transformation and improving healthcare delivery through innovative technology solutions.">
+    <title>Hugo Monteiro | Public Health Intelligence, Digital Health and Health Data Science</title>
+    <meta name="description" content="Hugo Monteiro works across public health intelligence, digital health, health data science, screening analytics, surveillance, municipal health planning, health information systems, emergency information management, and BI in healthcare.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Hugo Monteiro - MD/MPH | Digital Health Specialist">
-    <meta property="og:description" content="Portuguese MD/MPH dedicated to digital health transformation and improving healthcare delivery through innovative technology solutions.">
+    <meta property="og:title" content="Hugo Monteiro | Public Health Intelligence, Digital Health and Health Data Science">
+    <meta property="og:description" content="Hugo Monteiro works across public health intelligence, digital health, health data science, screening analytics, surveillance, municipal health planning, health information systems, emergency information management, and BI in healthcare.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Hugo Monteiro - MD/MPH | Digital Health Specialist">
-    <meta name="twitter:description" content="Portuguese MD/MPH dedicated to digital health transformation and improving healthcare delivery through innovative technology solutions.">
+    <meta name="twitter:title" content="Hugo Monteiro | Public Health Intelligence, Digital Health and Health Data Science">
+    <meta name="twitter:description" content="Hugo Monteiro works across public health intelligence, digital health, health data science, screening analytics, surveillance, municipal health planning, health information systems, emergency information management, and BI in healthcare.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security headers should be sent via HTTP; keeping referrer policy here -->
@@ -47,42 +47,72 @@
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
-        "@type": "Person",
-        "name": "Hugo Monteiro",
-        "givenName": "Hugo",
-        "familyName": "Monteiro",
-        "jobTitle": ["Medical Doctor", "Public Health Physician", "Digital Health Specialist"],
-        "description": "MD/MPH dedicated to digital health transformation and improving healthcare delivery",
-        "url": "https://www.hfmonteiro.com",
-        "sameAs": [
-            "https://www.linkedin.com/in/hugo-monteiro/",
-            "https://orcid.org/0000-0002-6060-3335"
-        ],
-        "worksFor": [
+        "@graph": [
             {
-                "@type": "Organization",
-                "name": "ULS Gaia Espinho"
+                "@type": "Person",
+                "@id": "https://www.hfmonteiro.com/#person",
+                "name": "Hugo Monteiro",
+                "givenName": "Hugo",
+                "familyName": "Monteiro",
+                "jobTitle": [
+                    "Medical Doctor",
+                    "Public Health Physician",
+                    "Digital Health Specialist",
+                    "Public Health Intelligence Specialist",
+                    "Health Data Science Researcher",
+                    "BI in Healthcare Practitioner"
+                ],
+                "description": "MD/MPH working at the intersection of public health intelligence, digital health, health data science, screening analytics, surveillance, health information systems and healthcare BI. Public profile information is intentionally limited to documented roles and public identifiers.",
+                "url": "https://www.hfmonteiro.com",
+                "sameAs": [
+                    "https://www.linkedin.com/in/hugo-monteiro/",
+                    "https://orcid.org/0000-0002-6060-3335"
+                ],
+                "worksFor": [
+                    {
+                        "@type": "Organization",
+                        "name": "ULS Gaia Espinho"
+                    },
+                    {
+                        "@type": "Organization",
+                        "name": "Direção Executiva do SNS"
+                    },
+                    {
+                        "@type": "Organization",
+                        "name": "WHO/Europe"
+                    }
+                ],
+                "alumniOf": [
+                    {
+                        "@type": "EducationalOrganization",
+                        "name": "Medical School"
+                    }
+                ],
+                "knowsAbout": [
+                    "Public Health Intelligence",
+                    "Digital Health",
+                    "Health Data Science",
+                    "Screening Analytics",
+                    "Surveillance and Signal Detection",
+                    "Municipal Health Planning",
+                    "Health Information Systems",
+                    "Emergency Information Management",
+                    "BI in Healthcare",
+                    "Healthcare Technology",
+                    "Public Health"
+                ]
             },
             {
-                "@type": "Organization",
-                "name": "Direção Executiva do SNS"
-            },
-            {
-                "@type": "Organization",
-                "name": "WHO/Europe"
+                "@type": "ProfilePage",
+                "@id": "https://www.hfmonteiro.com/en/#profile",
+                "url": "https://www.hfmonteiro.com/en/",
+                "name": "Hugo Monteiro - Public Health Intelligence and Digital Health Profile",
+                "description": "Profile page for Hugo Monteiro, focused on public health intelligence, digital health and health data science.",
+                "inLanguage": "en",
+                "mainEntity": {
+                    "@id": "https://www.hfmonteiro.com/#person"
+                }
             }
-        ],
-        "alumniOf": [
-            {
-                "@type": "EducationalOrganization",
-                "name": "Medical School"
-            }
-        ],
-        "knowsAbout": [
-            "Digital Health",
-            "Public Health",
-            "Healthcare Technology",
-            "Health Data Science"
         ]
     }
     </script>
@@ -102,6 +132,7 @@
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
         <a href="/en/publications.html">Publications</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
@@ -128,7 +159,7 @@
     <main role="main" id="main">
         <section class="hero" aria-labelledby="welcome-heading">
             <h2 id="welcome-heading">Public Health and Digital Health</h2>
-            <p class="hero-text">Professional work at the intersection of public health, digital transformation, data, and health governance.</p>
+            <p class="hero-text">Public health intelligence for digital health decisions: connecting health data science, screening analytics, surveillance and signal detection, municipal health planning, health information systems, emergency information management, and BI in healthcare.</p>
             
             <div class="hero-actions">
                 <!-- CV link removed -->
@@ -141,6 +172,29 @@
                  loading="lazy"
                  width="200" 
                  height="200">
+        </section>
+
+
+
+        <section class="overview-cards flagship-anchors" aria-labelledby="flagship-heading">
+            <h2 id="flagship-heading">Flagship focus areas</h2>
+            <div class="cards-grid">
+                <article class="card flagship-card">
+                    <h3>Municipal Health Planning</h3>
+                    <p>Population-health intelligence for local priorities, indicators and decision cycles.</p>
+                    <a href="/en/projects.html#municipal-health-planning" class="card-link">See planning work</a>
+                </article>
+                <article class="card flagship-card">
+                    <h3>Screening Analytics</h3>
+                    <p>Dashboards and measures that clarify access, coverage, follow-up and programme performance.</p>
+                    <a href="/en/projects.html#screening-analytics" class="card-link">See screening work</a>
+                </article>
+                <article class="card flagship-card">
+                    <h3>Surveillance and Signal Detection</h3>
+                    <p>Repeatable reporting workflows for timely public-health signals and operational awareness.</p>
+                    <a href="/en/projects.html#surveillance-signal-detection" class="card-link">See surveillance work</a>
+                </article>
+            </div>
         </section>
 
         <section class="overview-cards" aria-labelledby="overview-heading">

--- a/en/projects.html
+++ b/en/projects.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Projects - Hugo Monteiro | Public Health, Digital Health and Applied AI Work</title>
-    <meta name="description" content="Selected public-facing project themes by Hugo Monteiro across public health planning, screening dashboards, surveillance reporting, GovTech, interoperability, and applied AI.">
+    <title>Projects - Hugo Monteiro | Public Health Intelligence and Digital Health Delivery</title>
+    <meta name="description" content="Selected project themes across public health intelligence, municipal health planning, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
     <meta name="author" content="Hugo Monteiro">
     <link rel="canonical" href="https://www.hfmonteiro.com/en/projects.html">
     <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/projects.html">
     <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/projetos.html">
     <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/projects.html">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Projects - Hugo Monteiro | Public Health, Digital Health and Applied AI Work">
-    <meta property="og:description" content="Selected public-facing project themes by Hugo Monteiro across public health planning, screening dashboards, surveillance reporting, GovTech, interoperability, and applied AI.">
+    <meta property="og:title" content="Projects - Hugo Monteiro | Public Health Intelligence and Digital Health Delivery">
+    <meta property="og:description" content="Selected project themes across public health intelligence, municipal health planning, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
@@ -21,8 +21,8 @@
     <meta property="og:locale" content="en_US">
     <meta property="og:locale:alternate" content="pt_PT">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Projects - Hugo Monteiro | Public Health, Digital Health and Applied AI Work">
-    <meta name="twitter:description" content="Selected public-facing project themes by Hugo Monteiro across public health planning, screening dashboards, surveillance reporting, GovTech, interoperability, and applied AI.">
+    <meta name="twitter:title" content="Projects - Hugo Monteiro | Public Health Intelligence and Digital Health Delivery">
+    <meta name="twitter:description" content="Selected project themes across public health intelligence, municipal health planning, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
@@ -45,6 +45,7 @@
         <a href="/en/experience.html">Experience</a>
         <a href="/en/projects.html" aria-current="page">Projects</a>
         <a href="/en/publications.html">Publications</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/contact.html">Contact</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle dark/light theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
@@ -63,22 +64,26 @@
                 <div>
                     <p class="eyebrow">Selected projects</p>
                     <h2>Projects</h2>
-                    <p class="lead">Applied work across public health, data, digital processes and responsible AI.</p>
+                    <p class="lead">Applied work across public health intelligence, digital health delivery, health data science and responsible analytics.</p>
                 </div>
             </header>
 
             <section class="projects-intro">
-                <p>A selection of applied work across public health, data and digital transformation. The examples are described at a public and aggregate level, focused on the problem, contribution and practical result.</p>
+                <p>A selection of applied work across public health intelligence, digital health, health data science and BI in healthcare. The examples are described at a public and aggregate level, focused on the problem, contribution and practical result.</p>
                 <div class="project-themes" aria-label="Project themes">
-                    <span>Public health planning</span>
-                    <span>Data and BI</span>
-                    <span>Digital processes</span>
-                    <span>Governed AI</span>
+                    <span>Municipal health planning</span>
+                    <span>Screening analytics</span>
+                    <span>Surveillance and signal detection</span>
+                    <span>Health information systems</span>
+                    <span>Emergency information management</span>
+                    <span>BI in healthcare</span>
                 </div>
             </section>
 
-            <section class="project-index" aria-label="Selected projects">
-                <article class="project-card">
+            <section class="project-index featured-projects" aria-labelledby="featured-projects-heading">
+                <h3 id="featured-projects-heading">Featured public health intelligence work</h3>
+                <p class="section-intro">Three flagship areas connect municipal health planning, screening analytics, and surveillance and signal detection.</p>
+                <article class="project-card" id="municipal-health-planning">
                     <div class="project-card__head">
                         <span class="project-number">01</span>
                         <p class="project-meta">Public health planning</p>
@@ -101,7 +106,7 @@
                         <span>Indicators</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="screening-analytics">
                     <div class="project-card__head">
                         <span class="project-number">02</span>
                         <p class="project-meta">Programme monitoring</p>
@@ -124,7 +129,7 @@
                         <span>Data</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="surveillance-signal-detection">
                     <div class="project-card__head">
                         <span class="project-number">03</span>
                         <p class="project-meta">Surveillance and reporting</p>
@@ -147,7 +152,12 @@
                         <span>Reporting</span>
                     </div>
                 </article>
-                <article class="project-card">
+            </section>
+
+            <section class="project-index supporting-projects" aria-labelledby="supporting-projects-heading">
+                <h3 id="supporting-projects-heading">Supporting digital health and health information systems work</h3>
+                <p class="section-intro">Additional public examples cover emergency information management, workflow digitisation, interoperability, and BI in healthcare.</p>
+                <article class="project-card" id="health-information-systems">
                     <div class="project-card__head">
                         <span class="project-number">04</span>
                         <p class="project-meta">Administrative digitalisation</p>
@@ -170,7 +180,7 @@
                         <span>Process</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="emergency-information-management">
                     <div class="project-card__head">
                         <span class="project-number">05</span>
                         <p class="project-meta">Care pathways</p>
@@ -193,7 +203,7 @@
                         <span>Collaboration</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="bi-healthcare-ai-prototypes">
                     <div class="project-card__head">
                         <span class="project-number">06</span>
                         <p class="project-meta">Applied AI and data science</p>

--- a/en/publications.html
+++ b/en/publications.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Publications - Hugo Monteiro | Digital Health Research Publications</title>
-    <meta name="description" content="Research publications by Hugo Monteiro in digital health, public health systems, and health data science, regularly updated from ORCID.">
+    <title>Publications - Hugo Monteiro | Digital Health and Health Data Science Research</title>
+    <meta name="description" content="Research publications by Hugo Monteiro in digital health, public health intelligence, health data science, screening analytics, surveillance, and health information systems, regularly updated from ORCID.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Publications - Hugo Monteiro | Digital Health Research Publications">
-    <meta property="og:description" content="Research publications by Hugo Monteiro in digital health, public health systems, and health data science, regularly updated from ORCID.">
+    <meta property="og:title" content="Publications - Hugo Monteiro | Digital Health and Health Data Science Research">
+    <meta property="og:description" content="Research publications by Hugo Monteiro in digital health, public health intelligence, health data science, screening analytics, surveillance, and health information systems, regularly updated from ORCID.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/publications.html">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Publications - Hugo Monteiro | Digital Health Research Publications">
-    <meta name="twitter:description" content="Research publications by Hugo Monteiro in digital health, public health systems, and health data science, regularly updated from ORCID.">
+    <meta name="twitter:title" content="Publications - Hugo Monteiro | Digital Health and Health Data Science Research">
+    <meta name="twitter:description" content="Research publications by Hugo Monteiro in digital health, public health intelligence, health data science, screening analytics, surveillance, and health information systems, regularly updated from ORCID.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security headers should be sent by the server/CDN -->
@@ -59,6 +59,7 @@
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
         <a href="/en/publications.html" aria-current="page">Publications</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
@@ -101,6 +102,7 @@
 
             <section id="publications-content" class="publications-section">
                 <!-- Publications content will be loaded here -->
+                <noscript><p class="static-publications-fallback"><a href="/publications/publications_en.html">Static publications fallback</a></p></noscript>
                 <div class="loading-message">
                     <p>Loading publications...</p>
                 </div>
@@ -118,7 +120,8 @@
                     <div class="resource-item">
                         <h4>Collaboration</h4>
                         <p>Scope for collaborative research proposals.</p>
-                        <a href="/en/contact.html" class="resource-link">Contact</a>
+                        <a href="/en/speaking-training.html">Speaking & Training</a>
+        <a href="/en/contact.html" class="resource-link">Contact</a>
                     </div>
                     
                     <!-- CV download link removed -->

--- a/en/research.html
+++ b/en/research.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Research - Hugo Monteiro | Digital Health & Public Health Research</title>
-    <meta name="description" content="Explore Hugo Monteiro's research interests in digital health systems, screening programs, health information systems, and data visualization in healthcare.">
+    <title>Research - Hugo Monteiro | Digital Health, Health Data Science and Surveillance Analytics</title>
+    <meta name="description" content="Research interests in digital health, health data science, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Research - Hugo Monteiro | Digital Health & Public Health Research">
-    <meta property="og:description" content="Explore Hugo Monteiro's research interests in digital health systems, screening programs, health information systems, and data visualization in healthcare.">
+    <meta property="og:title" content="Research - Hugo Monteiro | Digital Health, Health Data Science and Surveillance Analytics">
+    <meta property="og:description" content="Research interests in digital health, health data science, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/research.html">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Research - Hugo Monteiro | Digital Health & Public Health Research">
-    <meta name="twitter:description" content="Explore Hugo Monteiro's research interests in digital health systems, screening programs, health information systems, and data visualization in healthcare.">
+    <meta name="twitter:title" content="Research - Hugo Monteiro | Digital Health, Health Data Science and Surveillance Analytics">
+    <meta name="twitter:description" content="Research interests in digital health, health data science, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security headers should be sent by the server/CDN -->
@@ -59,6 +59,7 @@
         <a href="/en/experience.html">Experience</a>
                 <a href="/en/projects.html">Projects</a>
         <a href="/en/publications.html">Publications</a>
+        <a href="/en/speaking-training.html">Speaking & Training</a>
         <a href="/en/contact.html">Contact</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>

--- a/en/speaking-training.html
+++ b/en/speaking-training.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Speaking & Training - Hugo Monteiro | Public Health Intelligence and Digital Health</title>
+    <meta name="description" content="Speaking and training topics by Hugo Monteiro across public health intelligence, digital health, health data science, screening analytics, surveillance and signal detection, health information systems, emergency information management, and BI in healthcare.">
+    <meta name="author" content="Hugo Monteiro">
+    <link rel="canonical" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Speaking & Training - Hugo Monteiro | Public Health Intelligence and Digital Health">
+    <meta property="og:description" content="Speaking and training topics across public health intelligence, digital health, health data science, screening analytics, surveillance, health information systems, emergency information management, and BI in healthcare.">
+    <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta property="og:url" content="https://www.hfmonteiro.com/en/speaking-training.html">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:locale:alternate" content="pt_PT">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Speaking & Training - Hugo Monteiro | Public Health Intelligence and Digital Health">
+    <meta name="twitter:description" content="Speaking and training topics across public health intelligence, digital health, health data science, screening analytics, surveillance, health information systems, emergency information management, and BI in healthcare.">
+    <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
+    <link rel="icon" type="image/png" href="/assets/img/favicon.png">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-v2projects" as="style">
+    <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-v2projects">
+</head>
+<body>
+    <a href="#main" class="skip-link">Skip to main content</a>
+    <header><h1>Hugo Monteiro</h1><p class="subtitle">MD/MPH | Digital Health Specialist</p></header>
+    <nav role="navigation" aria-label="Main navigation">
+        <a href="/en/">Home</a>
+        <a href="/en/about.html">About</a>
+        <a href="/en/research.html">Research</a>
+        <a href="/en/experience.html">Experience</a>
+        <a href="/en/projects.html">Projects</a>
+        <a href="/en/publications.html">Publications</a>
+        <a href="/en/speaking-training.html" aria-current="page">Speaking & Training</a>
+        <a href="/en/contact.html">Contact</a>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme"><svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg><svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg></button>
+        <div class="lang-switcher" role="group" aria-label="Language switcher"><a href="/en/speaking-training.html" rel="alternate" hreflang="en" class="lang-active" aria-current="true" aria-label="Selected language">EN</a> | <a href="/pt/formacao-palestras.html" rel="alternate" hreflang="pt-PT">PT</a></div>
+    </nav>
+    <main role="main" id="main">
+        <article class="page-content">
+            <header class="page-header"><h2>Speaking & Training</h2><p class="lead">Practical sessions on public health intelligence, digital health and health data science.</p></header>
+            <section class="research-areas">
+                <h3>Topics</h3>
+                <div class="research-grid">
+                    <article class="research-item"><h4>Public Health Intelligence and BI in Healthcare</h4><p>How to align indicators, dashboards and decision cadences for population-health operations.</p></article>
+                    <article class="research-item"><h4>Screening Analytics</h4><p>Using programme data to understand coverage, follow-up, variation and operational bottlenecks.</p></article>
+                    <article class="research-item"><h4>Surveillance and Signal Detection</h4><p>Designing repeatable reporting, alerting and review routines for public-health awareness.</p></article>
+                    <article class="research-item"><h4>Health Information Systems and Emergency Information Management</h4><p>Connecting digital workflows, data governance and human review in routine and emergency contexts.</p></article>
+                </div>
+            </section>
+            <section class="content-section"><h3>Collaboration</h3><p>For invited talks, workshops or training discussions, use the professional channels on the contact page.</p><p><a href="/en/contact.html" class="btn btn-primary">Contact</a></p></section>
+        </article>
+    </main>
+    <footer><p>&copy; <span id="current-year"></span> Hugo Monteiro. <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener" class="orcid-link">ORCID</a> | <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener">LinkedIn</a> | <a href="/en/legal.html">Legal</a></p></footer>
+    <button id="scroll-to-top" class="scroll-to-top" aria-label="Scroll to top" title="Back to top"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"></polyline></svg></button>
+    <script src="/assets/js/script.js?v=20260521" defer></script>
+</body>
+</html>

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Contacto - Hugo Monteiro | Canais Profissionais e Colaboração</title>
-    <meta name="description" content="Canais profissionais para colaboração em saúde digital, investigação, consultoria e participação em eventos. Perfis públicos no LinkedIn e ORCID.">
+    <title>Contacto - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital</title>
+    <meta name="description" content="Canais profissionais para colaboração em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Contacto Hugo Monteiro - Especialista em Saúde Digital">
-    <meta property="og:description" content="Canais profissionais para colaboração em saúde digital, investigação, consultoria e participação em eventos.">
+    <meta property="og:title" content="Contacto - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital">
+    <meta property="og:description" content="Canais profissionais para colaboração em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/contacto.html">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Contacto Hugo Monteiro - Especialista em Saúde Digital">
-    <meta name="twitter:description" content="Canais profissionais para colaboração em saúde digital, investigação, consultoria e participação em eventos.">
+    <meta name="twitter:title" content="Contacto - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital">
+    <meta name="twitter:description" content="Canais profissionais para colaboração em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -60,6 +60,7 @@
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
         <a href="/pt/publicacoes.html">Publicações</a>
+        <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
         <a href="/pt/contacto.html" aria-current="page">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
@@ -79,7 +80,8 @@
 
         <div class="lang-switcher" role="group" aria-label="Alternador de idioma">
             <a href="/en/contact.html" rel="alternate" hreflang="en">EN</a> |
-            <a href="/pt/contacto.html" rel="alternate" hreflang="pt-PT" class="lang-active" aria-current="true" aria-label="Idioma selecionado">PT</a>
+            <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
+        <a href="/pt/contacto.html" rel="alternate" hreflang="pt-PT" class="lang-active" aria-current="true" aria-label="Idioma selecionado">PT</a>
         </div>
     </nav>
 

--- a/pt/formacao-palestras.html
+++ b/pt/formacao-palestras.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="pt-PT">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Formação e Palestras - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital</title>
+    <meta name="description" content="Temas de formação e palestras de Hugo Monteiro em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
+    <meta name="author" content="Hugo Monteiro">
+    <link rel="canonical" href="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/speaking-training.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Formação e Palestras - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital">
+    <meta property="og:description" content="Temas de formação e palestras em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
+    <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta property="og:url" content="https://www.hfmonteiro.com/pt/formacao-palestras.html">
+    <meta property="og:locale" content="pt_PT">
+    <meta property="og:locale:alternate" content="en_US">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Formação e Palestras - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital">
+    <meta name="twitter:description" content="Temas de formação e palestras em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
+    <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
+    <link rel="icon" type="image/png" href="/assets/img/favicon.png">
+    <link rel="preload" href="/assets/css/styles.css?v=20260521-v2projects" as="style">
+    <link rel="preload" href="/assets/js/script.js?v=20260521" as="script">
+    <link rel="stylesheet" href="/assets/css/styles.css?v=20260521-v2projects">
+</head>
+<body>
+    <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
+    <header><h1>Hugo Monteiro</h1><p class="subtitle">MD/MPH | Especialista em Saúde Digital</p></header>
+    <nav role="navigation" aria-label="Navegação principal">
+        <a href="/pt/">Início</a>
+        <a href="/pt/sobre.html">Sobre</a>
+        <a href="/pt/investigacao.html">Investigação</a>
+        <a href="/pt/experiencia.html">Experiência</a>
+        <a href="/pt/projetos.html">Projetos</a>
+        <a href="/pt/publicacoes.html">Publicações</a>
+        <a href="/pt/formacao-palestras.html" aria-current="page">Formação e Palestras</a>
+        <a href="/pt/contacto.html">Contacto</a>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema"><svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg><svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg></button>
+        <div class="lang-switcher" role="group" aria-label="Alternador de idioma"><a href="/en/speaking-training.html" rel="alternate" hreflang="en">EN</a> | <a href="/pt/formacao-palestras.html" rel="alternate" hreflang="pt-PT" class="lang-active" aria-current="true" aria-label="Idioma selecionado">PT</a></div>
+    </nav>
+    <main role="main" id="main">
+        <article class="page-content">
+            <header class="page-header"><h2>Formação e Palestras</h2><p class="lead">Sessões práticas sobre inteligência em saúde pública, saúde digital e ciência de dados em saúde.</p></header>
+            <section class="research-areas">
+                <h3>Temas</h3>
+                <div class="research-grid">
+                    <article class="research-item"><h4>Inteligência em Saúde Pública e BI em Saúde</h4><p>Alinhar indicadores, dashboards e ciclos de decisão para operações de saúde populacional.</p></article>
+                    <article class="research-item"><h4>Análise de Rastreios</h4><p>Utilizar dados de programas para compreender cobertura, seguimento, variação e estrangulamentos operacionais.</p></article>
+                    <article class="research-item"><h4>Vigilância e Deteção de Sinais</h4><p>Desenhar rotinas repetíveis de reporte, alerta e revisão para consciência em saúde pública.</p></article>
+                    <article class="research-item"><h4>Sistemas de Informação em Saúde e Gestão de Informação em Emergência</h4><p>Ligar fluxos digitais, governação de dados e revisão humana em contextos de rotina e emergência.</p></article>
+                </div>
+            </section>
+            <section class="content-section"><h3>Colaboração</h3><p>Para palestras convidadas, workshops ou discussões de formação, utilize os canais profissionais na página de contacto.</p><p><a href="/pt/contacto.html" class="btn btn-primary">Contacto</a></p></section>
+        </article>
+    </main>
+    <footer><p>&copy; <span id="current-year"></span> Hugo Monteiro. <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener" class="orcid-link">ORCID</a> | <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener">LinkedIn</a> | <a href="/pt/legal.html">Aviso Legal</a></p></footer>
+    <button id="scroll-to-top" class="scroll-to-top" aria-label="Voltar ao topo" title="Voltar ao topo"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"></polyline></svg></button>
+    <script src="/assets/js/script.js?v=20260521" defer></script>
+</body>
+</html>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Hugo Monteiro - MD/MPH | Especialista em Saúde Digital</title>
-    <meta name="description" content="Hugo Monteiro é um médico português com MPH dedicado à transformação digital da saúde e ao melhoramento da prestação de cuidados através de soluções tecnológicas inovadoras.">
+    <title>Hugo Monteiro | Inteligência em Saúde Pública, Saúde Digital e Ciência de Dados em Saúde</title>
+    <meta name="description" content="Hugo Monteiro trabalha em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Hugo Monteiro - MD/MPH | Especialista em Saúde Digital">
-    <meta property="og:description" content="Médico português com MPH dedicado à transformação digital da saúde e ao melhoramento da prestação de cuidados através de soluções tecnológicas inovadoras.">
+    <meta property="og:title" content="Hugo Monteiro | Inteligência em Saúde Pública, Saúde Digital e Ciência de Dados em Saúde">
+    <meta property="og:description" content="Hugo Monteiro trabalha em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Hugo Monteiro - MD/MPH | Especialista em Saúde Digital">
-    <meta name="twitter:description" content="Médico português com MPH dedicado à transformação digital da saúde e ao melhoramento da prestação de cuidados através de soluções tecnológicas inovadoras.">
+    <meta name="twitter:title" content="Hugo Monteiro | Inteligência em Saúde Pública, Saúde Digital e Ciência de Dados em Saúde">
+    <meta name="twitter:description" content="Hugo Monteiro trabalha em inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security headers should be sent via HTTP; keeping referrer policy here -->
@@ -46,30 +46,72 @@
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
-        "@type": "Person",
-        "name": "Hugo Monteiro",
-        "givenName": "Hugo",
-        "familyName": "Monteiro",
-        "jobTitle": ["Médico", "Médico de Saúde Pública", "Especialista em Saúde Digital"],
-        "description": "MD/MPH dedicado à transformação digital da saúde e ao melhoramento da prestação de cuidados",
-        "url": "https://www.hfmonteiro.com",
-        "sameAs": [
-            "https://www.linkedin.com/in/hugo-monteiro/",
-            "https://orcid.org/0000-0002-6060-3335"
-        ],
-        "worksFor": [
-            { "@type": "Organization", "name": "ULS Gaia Espinho" },
-            { "@type": "Organization", "name": "Direção Executiva do SNS" },
-            { "@type": "Organization", "name": "OMS/Europa" }
-        ],
-        "alumniOf": [
-            { "@type": "EducationalOrganization", "name": "Faculdade de Medicina" }
-        ],
-        "knowsAbout": [
-            "Saúde Digital",
-            "Saúde Pública",
-            "Tecnologia em Saúde",
-            "Ciência de Dados em Saúde"
+        "@graph": [
+            {
+                "@type": "Person",
+                "@id": "https://www.hfmonteiro.com/#person",
+                "name": "Hugo Monteiro",
+                "givenName": "Hugo",
+                "familyName": "Monteiro",
+                "jobTitle": [
+                    "Médico",
+                    "Médico de Saúde Pública",
+                    "Especialista em Saúde Digital",
+                    "Especialista em Inteligência em Saúde Pública",
+                    "Investigador em Ciência de Dados em Saúde",
+                    "Profissional de BI em Saúde"
+                ],
+                "description": "MD/MPH com trabalho na interseção entre inteligência em saúde pública, saúde digital, ciência de dados em saúde, análise de rastreios, vigilância, sistemas de informação em saúde e BI em saúde. A informação pública do perfil limita-se a funções documentadas e identificadores públicos.",
+                "url": "https://www.hfmonteiro.com",
+                "sameAs": [
+                    "https://www.linkedin.com/in/hugo-monteiro/",
+                    "https://orcid.org/0000-0002-6060-3335"
+                ],
+                "worksFor": [
+                    {
+                        "@type": "Organization",
+                        "name": "ULS Gaia Espinho"
+                    },
+                    {
+                        "@type": "Organization",
+                        "name": "Direção Executiva do SNS"
+                    },
+                    {
+                        "@type": "Organization",
+                        "name": "OMS/Europa"
+                    }
+                ],
+                "alumniOf": [
+                    {
+                        "@type": "EducationalOrganization",
+                        "name": "Faculdade de Medicina"
+                    }
+                ],
+                "knowsAbout": [
+                    "Inteligência em Saúde Pública",
+                    "Saúde Digital",
+                    "Ciência de Dados em Saúde",
+                    "Análise de Rastreios",
+                    "Vigilância e Deteção de Sinais",
+                    "Planeamento Municipal em Saúde",
+                    "Sistemas de Informação em Saúde",
+                    "Gestão de Informação em Emergência",
+                    "BI em Saúde",
+                    "Tecnologia em Saúde",
+                    "Saúde Pública"
+                ]
+            },
+            {
+                "@type": "ProfilePage",
+                "@id": "https://www.hfmonteiro.com/pt/#profile",
+                "url": "https://www.hfmonteiro.com/pt/",
+                "name": "Hugo Monteiro - Perfil de Inteligência em Saúde Pública e Saúde Digital",
+                "description": "Página de perfil de Hugo Monteiro, centrada em inteligência em saúde pública, saúde digital e ciência de dados em saúde.",
+                "inLanguage": "pt-PT",
+                "mainEntity": {
+                    "@id": "https://www.hfmonteiro.com/#person"
+                }
+            }
         ]
     }
     </script>
@@ -89,6 +131,7 @@
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
         <a href="/pt/publicacoes.html">Publicações</a>
+        <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
         <a href="/pt/contacto.html">Contacto</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -115,7 +158,7 @@
     <main role="main" id="main">
         <section class="hero" aria-labelledby="welcome-heading">
             <h2 id="welcome-heading">Saúde Pública e Saúde Digital</h2>
-            <p class="hero-text">Trabalho profissional na interseção entre saúde pública, transformação digital, dados e governação em saúde.</p>
+            <p class="hero-text">Inteligência em saúde pública para decisões em saúde digital: ligação entre ciência de dados em saúde, análise de rastreios, vigilância e deteção de sinais, planeamento municipal em saúde, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.</p>
             
             <div class="hero-actions">
                 <a href="/pt/sobre.html" class="btn btn-secondary">Ver perfil</a>
@@ -127,6 +170,29 @@
                  loading="lazy"
                  width="200" 
                  height="200">
+        </section>
+
+
+
+        <section class="overview-cards flagship-anchors" aria-labelledby="flagship-heading">
+            <h2 id="flagship-heading">Áreas emblemáticas</h2>
+            <div class="cards-grid">
+                <article class="card flagship-card">
+                    <h3>Planeamento Municipal em Saúde</h3>
+                    <p>Inteligência populacional para prioridades locais, indicadores e ciclos de decisão.</p>
+                    <a href="/pt/projetos.html#planeamento-municipal-saude" class="card-link">Ver trabalho de planeamento</a>
+                </article>
+                <article class="card flagship-card">
+                    <h3>Análise de Rastreios</h3>
+                    <p>Dashboards e métricas para clarificar acesso, cobertura, seguimento e desempenho dos programas.</p>
+                    <a href="/pt/projetos.html#analise-rastreios" class="card-link">Ver trabalho em rastreios</a>
+                </article>
+                <article class="card flagship-card">
+                    <h3>Vigilância e Deteção de Sinais</h3>
+                    <p>Fluxos repetíveis de reporte para sinais de saúde pública e consciência operacional atempada.</p>
+                    <a href="/pt/projetos.html#vigilancia-detecao-sinais" class="card-link">Ver trabalho de vigilância</a>
+                </article>
+            </div>
         </section>
 
         <section class="overview-cards" aria-labelledby="overview-heading">

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública</title>
-    <meta name="description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
+    <title>Investigação - Hugo Monteiro | Saúde Digital, Ciência de Dados em Saúde e Vigilância</title>
+    <meta name="description" content="Interesses de investigação em saúde digital, ciência de dados em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública">
-    <meta property="og:description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
+    <meta property="og:title" content="Investigação - Hugo Monteiro | Saúde Digital, Ciência de Dados em Saúde e Vigilância">
+    <meta property="og:description" content="Interesses de investigação em saúde digital, ciência de dados em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/investigacao.html">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública">
-    <meta name="twitter:description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
+    <meta name="twitter:title" content="Investigação - Hugo Monteiro | Saúde Digital, Ciência de Dados em Saúde e Vigilância">
+    <meta name="twitter:description" content="Interesses de investigação em saúde digital, ciência de dados em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -60,6 +60,7 @@
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
         <a href="/pt/publicacoes.html">Publicações</a>
+        <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>

--- a/pt/projetos.html
+++ b/pt/projetos.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Projetos - Hugo Monteiro | Saúde Pública, Saúde Digital e IA Aplicada</title>
-    <meta name="description" content="Projetos e áreas de trabalho selecionadas de Hugo Monteiro em planeamento em saúde pública, dashboards de rastreio, vigilância, GovTech, interoperabilidade e IA aplicada.">
+    <title>Projetos - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital</title>
+    <meta name="description" content="Temas de projeto em inteligência em saúde pública, planeamento municipal em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="author" content="Hugo Monteiro">
     <link rel="canonical" href="https://www.hfmonteiro.com/pt/projetos.html">
     <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/projects.html">
     <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/projetos.html">
     <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/projects.html">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Projetos - Hugo Monteiro | Saúde Pública, Saúde Digital e IA Aplicada">
-    <meta property="og:description" content="Projetos e áreas de trabalho selecionadas de Hugo Monteiro em planeamento em saúde pública, dashboards de rastreio, vigilância, GovTech, interoperabilidade e IA aplicada.">
+    <meta property="og:title" content="Projetos - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital">
+    <meta property="og:description" content="Temas de projeto em inteligência em saúde pública, planeamento municipal em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
@@ -21,8 +21,8 @@
     <meta property="og:locale" content="pt_PT">
     <meta property="og:locale:alternate" content="en_US">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Projetos - Hugo Monteiro | Saúde Pública, Saúde Digital e IA Aplicada">
-    <meta name="twitter:description" content="Projetos e áreas de trabalho selecionadas de Hugo Monteiro em planeamento em saúde pública, dashboards de rastreio, vigilância, GovTech, interoperabilidade e IA aplicada.">
+    <meta name="twitter:title" content="Projetos - Hugo Monteiro | Inteligência em Saúde Pública e Saúde Digital">
+    <meta name="twitter:description" content="Temas de projeto em inteligência em saúde pública, planeamento municipal em saúde, análise de rastreios, vigilância e deteção de sinais, sistemas de informação em saúde, gestão de informação em emergência e BI em saúde.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
@@ -45,6 +45,7 @@
         <a href="/pt/experiencia.html">Experiência</a>
         <a href="/pt/projetos.html" aria-current="page">Projetos</a>
         <a href="/pt/publicacoes.html">Publicações</a>
+        <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
         <a href="/pt/contacto.html">Contacto</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema claro/escuro" title="Alternar tema claro/escuro">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
@@ -63,7 +64,7 @@
                 <div>
                     <p class="eyebrow">Projetos selecionados</p>
                     <h2>Projetos</h2>
-                    <p class="lead">Trabalho aplicado em saúde pública, dados, processos digitais e IA responsável.</p>
+                    <p class="lead">Trabalho aplicado em inteligência em saúde pública, saúde digital, ciência de dados em saúde e analítica responsável.</p>
                 </div>
             </header>
 
@@ -77,8 +78,10 @@
                 </div>
             </section>
 
-            <section class="project-index" aria-label="Projetos selecionados">
-                <article class="project-card">
+            <section class="project-index featured-projects" aria-labelledby="featured-projects-heading">
+                <h3 id="featured-projects-heading">Trabalho emblemático em inteligência em saúde pública</h3>
+                <p class="section-intro">Três áreas centrais ligam planeamento municipal em saúde, análise de rastreios e vigilância e deteção de sinais.</p>
+                <article class="project-card" id="planeamento-municipal-saude">
                     <div class="project-card__head">
                         <span class="project-number">01</span>
                         <p class="project-meta">Planeamento em saúde pública</p>
@@ -101,7 +104,7 @@
                         <span>Indicadores</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="analise-rastreios">
                     <div class="project-card__head">
                         <span class="project-number">02</span>
                         <p class="project-meta">Monitorização de programas</p>
@@ -124,7 +127,7 @@
                         <span>Dados</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="vigilancia-detecao-sinais">
                     <div class="project-card__head">
                         <span class="project-number">03</span>
                         <p class="project-meta">Vigilância e reporte</p>
@@ -147,7 +150,12 @@
                         <span>Reporte</span>
                     </div>
                 </article>
-                <article class="project-card">
+            </section>
+
+            <section class="project-index supporting-projects" aria-labelledby="supporting-projects-heading">
+                <h3 id="supporting-projects-heading">Trabalho de suporte em saúde digital e sistemas de informação em saúde</h3>
+                <p class="section-intro">Exemplos adicionais cobrem gestão de informação em emergência, digitalização de fluxos, interoperabilidade e BI em saúde.</p>
+                <article class="project-card" id="sistemas-informacao-saude">
                     <div class="project-card__head">
                         <span class="project-number">04</span>
                         <p class="project-meta">Digitalização administrativa</p>
@@ -170,7 +178,7 @@
                         <span>Processos</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="gestao-informacao-emergencia">
                     <div class="project-card__head">
                         <span class="project-number">05</span>
                         <p class="project-meta">Percursos assistenciais</p>
@@ -193,7 +201,7 @@
                         <span>Colaboração</span>
                     </div>
                 </article>
-                <article class="project-card">
+                <article class="project-card" id="bi-saude-prototipos-ia">
                     <div class="project-card__head">
                         <span class="project-number">06</span>
                         <p class="project-meta">IA e ciência de dados aplicada</p>

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital</title>
-    <meta name="description" content="Publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas regularmente a partir do ORCID.">
+    <title>Publicações - Hugo Monteiro | Saúde Digital e Ciência de Dados em Saúde</title>
+    <meta name="description" content="Publicações de investigação de Hugo Monteiro em saúde digital, inteligência em saúde pública, ciência de dados em saúde, análise de rastreios, vigilância e sistemas de informação em saúde, atualizadas regularmente a partir do ORCID.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital">
-    <meta property="og:description" content="Publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas regularmente a partir do ORCID.">
+    <meta property="og:title" content="Publicações - Hugo Monteiro | Saúde Digital e Ciência de Dados em Saúde">
+    <meta property="og:description" content="Publicações de investigação de Hugo Monteiro em saúde digital, inteligência em saúde pública, ciência de dados em saúde, análise de rastreios, vigilância e sistemas de informação em saúde, atualizadas regularmente a partir do ORCID.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/publicacoes.html">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital">
-    <meta name="twitter:description" content="Publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas regularmente a partir do ORCID.">
+    <meta name="twitter:title" content="Publicações - Hugo Monteiro | Saúde Digital e Ciência de Dados em Saúde">
+    <meta name="twitter:description" content="Publicações de investigação de Hugo Monteiro em saúde digital, inteligência em saúde pública, ciência de dados em saúde, análise de rastreios, vigilância e sistemas de informação em saúde, atualizadas regularmente a partir do ORCID.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -60,6 +60,7 @@
         <a href="/pt/experiencia.html">Experiência</a>
                 <a href="/pt/projetos.html">Projetos</a>
         <a href="/pt/publicacoes.html" aria-current="page">Publicações</a>
+        <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
         <a href="/pt/contacto.html">Contacto</a>        <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema escuro/claro" title="Alternar tema">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="5"></circle>
@@ -102,6 +103,7 @@
 
             <section id="publications-content" class="publications-section">
                 <!-- Publications content will be loaded here -->
+                <noscript><p class="static-publications-fallback"><a href="/publications/publications_pt.html">Fallback estático de publicações</a></p></noscript>
                 <div class="loading-message">
                     <p>A carregar publicações...</p>
                 </div>
@@ -119,7 +121,8 @@
                     <div class="resource-item">
                         <h4>Colaboração</h4>
                         <p>Enquadramento para propostas de investigação colaborativa.</p>
-                        <a href="/pt/contacto.html" class="resource-link">Contacto</a>
+                        <a href="/pt/formacao-palestras.html">Formação e Palestras</a>
+        <a href="/pt/contacto.html" class="resource-link">Contacto</a>
                     </div>
                     
                     <!-- Link de descarregamento de CV removido -->

--- a/scripts/smoke_site.spec.js
+++ b/scripts/smoke_site.spec.js
@@ -51,7 +51,10 @@ for (const testCase of cases) {
     expect(overflow).toBeFalsy();
 
     if (testCase.projects) {
-      await expect(page.locator('.project-card')).toHaveCount(6);
+      await expect(page.locator('.featured-projects')).toBeVisible();
+      await expect(page.locator('.supporting-projects')).toBeVisible();
+      await expect(page.locator('.featured-projects .project-card')).toHaveCount(3);
+      await expect(page.locator('.supporting-projects .project-card').first()).toBeVisible();
       await expect(page.locator('.project-facts dt').first()).toBeVisible();
       const bodyText = await page.locator('body').innerText();
       expect(bodyText).not.toMatch(/sanitiz/i);

--- a/scripts/validate_site.js
+++ b/scripts/validate_site.js
@@ -34,6 +34,13 @@ function walk(dir, result = []) {
   return result;
 }
 
+
+function extractHref(html, rel, hreflang) {
+  const pattern = new RegExp(`<link\\s+rel="${rel}"(?:\\s+hreflang="${hreflang}")?\\s+href="([^"]+)"`, 'i');
+  const match = html.match(pattern);
+  return match ? match[1] : '';
+}
+
 function localTargetExists(url) {
   const clean = url.split('#')[0].split('?')[0];
   if (!clean || clean === '/') return exists('index.html');
@@ -49,6 +56,7 @@ const pages = [
   { file: 'en/experience.html', lang: 'en', alternate: '/pt/experiencia.html' },
   { file: 'en/projects.html', lang: 'en', alternate: '/pt/projetos.html' },
   { file: 'en/publications.html', lang: 'en', alternate: '/pt/publicacoes.html' },
+  { file: 'en/speaking-training.html', lang: 'en', alternate: '/pt/formacao-palestras.html' },
   { file: 'en/contact.html', lang: 'en', alternate: '/pt/contacto.html' },
   { file: 'pt/index.html', lang: 'pt-PT', alternate: '/en/' },
   { file: 'pt/sobre.html', lang: 'pt-PT', alternate: '/en/about.html' },
@@ -56,6 +64,7 @@ const pages = [
   { file: 'pt/experiencia.html', lang: 'pt-PT', alternate: '/en/experience.html' },
   { file: 'pt/projetos.html', lang: 'pt-PT', alternate: '/en/projects.html' },
   { file: 'pt/publicacoes.html', lang: 'pt-PT', alternate: '/en/publications.html' },
+  { file: 'pt/formacao-palestras.html', lang: 'pt-PT', alternate: '/en/speaking-training.html' },
   { file: 'pt/contacto.html', lang: 'pt-PT', alternate: '/en/contact.html' },
   { file: '404.html', lang: 'en', canonical: false, hreflang: false, sitemap: false }
 ];
@@ -83,6 +92,45 @@ check(!css.includes('.publication-tools'), 'publication filter CSS has been remo
 check(!css.includes('project-card__top'), 'stale project-card__top selector is absent');
 check(!css.includes('project-evidence'), 'stale project-evidence selector is absent');
 
+
+const homepageChecks = [
+  {
+    file: 'en/index.html',
+    thesis: 'Public health intelligence for digital health decisions',
+    flagship: ['Municipal Health Planning', 'Screening Analytics', 'Surveillance and Signal Detection']
+  },
+  {
+    file: 'pt/index.html',
+    thesis: 'Inteligência em saúde pública para decisões em saúde digital',
+    flagship: ['Planeamento Municipal em Saúde', 'Análise de Rastreios', 'Vigilância e Deteção de Sinais']
+  }
+];
+
+for (const { file, thesis, flagship } of homepageChecks) {
+  const html = read(file);
+  check(html.includes(thesis), `${file} includes homepage thesis`);
+  check((html.match(/class="card flagship-card"/g) || []).length === 3, `${file} has three flagship cards`);
+  for (const label of flagship) check(html.includes(label), `${file} includes flagship anchor/card: ${label}`);
+}
+
+const projectExpectations = [
+  { file: 'en/projects.html', featured: ['Health Situation Diagnosis and Municipal Health Planning', 'Screening Programme Dashboards', 'Digital Surveillance Bulletins'], supporting: ['Sanitary Pool Records', 'ICTUSnet and Pathway Coordination', 'AI, NLP and GIS Prototypes'] },
+  { file: 'pt/projetos.html', featured: ['Diagnóstico de Situação de Saúde e Planeamento Municipal', 'Dashboards de Programas de Rastreio', 'Boletins de Vigilância Digitais'], supporting: ['Registos Sanitários de Piscinas', 'ICTUSnet e Coordenação de Percursos', 'Protótipos com IA, NLP e GIS'] }
+];
+
+for (const { file, featured, supporting } of projectExpectations) {
+  const html = read(file);
+  check(html.includes('featured-projects'), `${file} has featured projects section`);
+  check(html.includes('supporting-projects'), `${file} has supporting projects section`);
+  for (const name of featured) check(html.includes(name), `${file} keeps featured project: ${name}`);
+  for (const name of supporting) check(html.includes(name), `${file} keeps supporting project: ${name}`);
+}
+
+for (const file of ['en/publications.html', 'pt/publicacoes.html']) {
+  const html = read(file);
+  check(html.includes('static-publications-fallback'), `${file} has static publications fallback link`);
+}
+
 for (const page of pages) {
   check(exists(page.file), `${page.file} exists`);
   const html = read(page.file);
@@ -91,11 +139,16 @@ for (const page of pages) {
   check(/<title>[^<]{10,}<\/title>/.test(html), `${page.file} has descriptive title`);
   check(/<meta name="description" content="[^"]{50,}">/.test(html), `${page.file} has meta description`);
   if (page.canonical !== false) {
-    check(/<link rel="canonical" href="https:\/\/www\.hfmonteiro\.com\//.test(html), `${page.file} has absolute canonical`);
+    const expectedCanonical = `https://www.hfmonteiro.com/${page.file.replace('index.html', '')}`;
+    check(html.includes(`<link rel="canonical" href="${expectedCanonical}">`), `${page.file} has expected absolute canonical`);
   }
   if (page.hreflang !== false) {
     check(html.includes('hreflang="en"'), `${page.file} has English hreflang`);
     check(html.includes('hreflang="pt-PT"'), `${page.file} has Portuguese hreflang`);
+    const expectedEnglish = page.lang === 'en' ? `https://www.hfmonteiro.com/${page.file.replace('index.html', '')}` : `https://www.hfmonteiro.com${page.alternate}`;
+    const expectedPortuguese = page.lang === 'pt-PT' ? `https://www.hfmonteiro.com/${page.file.replace('index.html', '')}` : `https://www.hfmonteiro.com${page.alternate}`;
+    check(html.includes(`<link rel="alternate" hreflang="en" href="${expectedEnglish}">`), `${page.file} has expected English hreflang URL`);
+    check(html.includes(`<link rel="alternate" hreflang="pt-PT" href="${expectedPortuguese}">`), `${page.file} has expected Portuguese hreflang URL`);
   }
   if (page.alternate) {
     check(html.includes(`href="${page.alternate}"`) || html.includes(`href="https://www.hfmonteiro.com${page.alternate}"`), `${page.file} links to alternate language page`);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,137 +1,140 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  
-  <!-- Root redirect -->
   <url>
     <loc>https://www.hfmonteiro.com/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/" />
   </url>
-
-  <!-- English pages -->
   <url>
     <loc>https://www.hfmonteiro.com/en/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/" />
   </url>
-  
   <url>
     <loc>https://www.hfmonteiro.com/en/about.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/about.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/sobre.html" />
   </url>
-  
   <url>
     <loc>https://www.hfmonteiro.com/en/research.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/research.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/investigacao.html" />
   </url>
-  
   <url>
     <loc>https://www.hfmonteiro.com/en/experience.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/experience.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/experiencia.html" />
   </url>
-    <url>
-        <loc>https://www.hfmonteiro.com/en/projects.html</loc>
-        <lastmod>2026-05-21</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
-    </url>
-  
+  <url>
+    <loc>https://www.hfmonteiro.com/en/projects.html</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/projects.html" />
+    <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/projetos.html" />
+  </url>
   <url>
     <loc>https://www.hfmonteiro.com/en/publications.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/publications.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/publicacoes.html" />
   </url>
-  
+  <url>
+    <loc>https://www.hfmonteiro.com/en/speaking-training.html</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html" />
+    <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html" />
+  </url>
   <url>
     <loc>https://www.hfmonteiro.com/en/contact.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/contact.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/contacto.html" />
   </url>
-
-  <!-- Portuguese pages -->
   <url>
     <loc>https://www.hfmonteiro.com/pt/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/" />
   </url>
-  
   <url>
     <loc>https://www.hfmonteiro.com/pt/sobre.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/about.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/sobre.html" />
   </url>
-  
   <url>
     <loc>https://www.hfmonteiro.com/pt/investigacao.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/research.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/investigacao.html" />
   </url>
-  
   <url>
     <loc>https://www.hfmonteiro.com/pt/experiencia.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/experience.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/experiencia.html" />
   </url>
-    <url>
-        <loc>https://www.hfmonteiro.com/pt/projetos.html</loc>
-        <lastmod>2026-05-21</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
-    </url>
-  
+  <url>
+    <loc>https://www.hfmonteiro.com/pt/projetos.html</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/projects.html" />
+    <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/projetos.html" />
+  </url>
   <url>
     <loc>https://www.hfmonteiro.com/pt/publicacoes.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/publications.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/publicacoes.html" />
   </url>
-  
+  <url>
+    <loc>https://www.hfmonteiro.com/pt/formacao-palestras.html</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/speaking-training.html" />
+    <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/formacao-palestras.html" />
+  </url>
   <url>
     <loc>https://www.hfmonteiro.com/pt/contacto.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/contact.html" />
     <xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/contacto.html" />
   </url>
-
 </urlset>


### PR DESCRIPTION
### Motivation
- Align site metadata and page copy to emphasise Public Health Intelligence, Digital Health and related domains (health data science, screening analytics, surveillance, municipal planning, health information systems, emergency information management and BI in healthcare).
- Make bilingual EN/PT pages consistent for canonical/hreflang, improve structured data for homepages, and add public-facing Speaking & Training content.
- Harden automated checks to reduce brittle assertions (e.g. exact project-card counts) and add coverage for new pages and fallbacks.

### Description
- Updated titles, meta descriptions and Open Graph/Twitter metadata across EN/PT pages including `en/index.html`, `pt/index.html`, `en/projects.html`, `pt/projetos.html`, `en/research.html`, `pt/investigacao.html`, `en/publications.html`, `pt/publicacoes.html`, `en/contact.html`, and `pt/contacto.html` to reflect the expanded topic set and keep canonical/hreflang parity.
- Improved homepage JSON-LD by replacing the single `Person` block with a `@graph` containing a `Person` and `ProfilePage`, adding documented `jobTitle` entries, careful `description` wording, and preserving `sameAs` ORCID/LinkedIn identifiers.
- Added homepage thesis text and three flagship anchor cards, split project listings into `featured-projects` and `supporting-projects` with stable `id` anchors for the three flagship areas and supporting projects, and kept all existing public project names.
- Added bilingual Speaking & Training pages (`en/speaking-training.html`, `pt/formacao-palestras.html`) with canonical/hreflang links and topic coverage; inserted links in site navs; added static publications fallbacks (`noscript` links) to `en/publications.html` and `pt/publicacoes.html`.
- Updated `sitemap.xml` to include the new Speaking & Training pages and refreshed alternates/`lastmod` entries.
- Updated `scripts/validate_site.js` to include the new pages, enforce homepage thesis and flagship-card checks, assert featured/supporting project sections and static publications fallback, and to validate expected absolute canonical/hreflang URLs.
- Hardened `scripts/smoke_site.spec.js` Playwright smoke assertions to check presence of `.featured-projects` and `.supporting-projects` and 3 featured cards instead of brittle total counts.

### Testing
- `node scripts/validate_site.js` executed and all validation checks passed (site validation output: "Site validation checks passed.").
- Syntax/quick checks on the test files were performed (`node -c scripts/smoke_site.spec.js` / `node -c scripts/validate_site.js`) and no syntax errors were reported.
- `git diff --check` was run and reported no issues.
- Playwright smoke run (`SITE_BASE_URL=http://127.0.0.1:4173 npx playwright test scripts/smoke_site.spec.js`) could not be executed in this environment because `@playwright/test` was not available/resolvable via `npx`, so full browser end-to-end Playwright runs were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a871b6a4832898d365eab074ea18)