### PR TITLE
Remove non-error development console logs

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -7,8 +7,7 @@
     // Configuration
     const CONFIG = {
         animationDelay: 100,
-        scrollOffset: 80,
-        greeting: 'Welcome to Hugo Monteiro\'s professional portfolio!'
+        scrollOffset: 80
     };
     
     // Utility functions
@@ -65,13 +64,6 @@
             // Initialize scroll to top button
             initializeScrollToTop();
 
-            // Performance monitoring
-            monitorPerformance();
-
-            // Log success message
-            console.log(CONFIG.greeting);
-            console.log('Website initialized successfully with modern enhancements');
-
         } catch (error) {
             console.error('Error initializing website:', error);
             // Fallback for critical functionality
@@ -117,8 +109,6 @@
             // Update button label
             updateThemeButtonLabel(themeToggleBtn, theme);
 
-            // Log for debugging
-            console.log(`Theme switched to: ${theme}`);
         });
 
         // Keyboard accessibility
@@ -252,7 +242,6 @@
             img.onload = function() {
                 profileImage.style.opacity = '1';
                 profileImage.setAttribute('aria-label', 'Hugo Monteiro professional headshot');
-                console.log('Profile image loaded successfully');
             };
             
             img.onerror = function() {
@@ -282,8 +271,7 @@
             // Add analytics tracking (if needed)
             link.addEventListener('click', function() {
                 const linkType = this.textContent.toLowerCase().trim();
-                console.log(`Contact link clicked: ${linkType}`);
-                
+
                 // Could integrate with analytics here
                 if (typeof gtag !== 'undefined') {
                     gtag('event', 'contact_click', {
@@ -339,30 +327,8 @@
         });
     }
 
-    // Performance monitoring
-    function monitorPerformance() {
-        if ('performance' in window) {
-            window.addEventListener('load', () => {
-                setTimeout(() => {
-                    const perfData = performance.getEntriesByType('navigation')[0];
-                    if (perfData) {
-                        console.log(`Page load time: ${Math.round(perfData.loadEventEnd - perfData.fetchStart)}ms`);
-                    }
-                    
-                    // Monitor core web vitals if available
-                    if ('web-vitals' in window) {
-                        // This would require importing web-vitals library
-                        console.log('Web Vitals monitoring available');
-                    }
-                }, 0);
-            });
-        }
-    }
-
     // Fallback initialization for older browsers
     function fallbackInitialization() {
-        console.log('Running fallback initialization');
-        
         // Basic year setting
         const yearElement = document.getElementById('current-year');
         if (yearElement) {


### PR DESCRIPTION
### Motivation

- Remove noisy development-only `console.log` calls that are not helpful in production and remove the unused `CONFIG.greeting` setting that existed solely for a debug message.
- Keep `console.warn` and `console.error` for actual recoverable issues and failures such as missing theme toggle, image fallback, or initialization errors.

### Description

- Removed `CONFIG.greeting` from `assets/js/script.js` and dropped initialization success logs emitted during `initializeWebsite`.
- Removed development `console.log` calls for theme switching, profile-image load success, contact-link clicks, and the performance/Web Vitals helper function and its invocation.
- Preserved `console.warn`/`console.error` usages for missing UI elements and load failures and kept existing accessibility/fallback logic intact.

### Testing

- Ran `node --check assets/js/script.js` to validate the JavaScript syntax and it succeeded.
- Ran site validation with `node scripts/validate_site.js` and the suite passed (`Site validation checks passed`).
- Confirmed no remaining development logs with `rg "console\.log" assets/js/script.js` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a8743e4483288d78389e4d4c3c1f)