### PR TITLE
Rebrand to 'Public Health Intelligence' + projects redesign, styles, and site validation tests

### DIFF
--- a/404.html
+++ b/404.html
@@ -93,7 +93,7 @@
 
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2190,3 +2190,103 @@ section h3 {
     min-height: 128px;
   }
 }
+
+/* Strategic portfolio hierarchy: featured case studies and supporting projects */
+.featured-work,
+.additional-applied-work,
+.request-guidance {
+  margin-top: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.featured-work > h3,
+.additional-applied-work > h3,
+.request-guidance > h3 {
+  margin-bottom: 0.75rem;
+}
+
+.section-note {
+  max-width: 860px;
+  color: var(--text-light);
+}
+
+.featured-project-grid,
+.supporting-project-grid {
+  display: grid;
+  gap: var(--v2-gap);
+}
+
+.featured-project-grid {
+  grid-template-columns: 1fr;
+}
+
+.supporting-project-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
+}
+
+.featured-project-card {
+  border-left-width: 6px;
+  padding: clamp(1.15rem, 1.8vw, 1.75rem);
+  background: #ffffff;
+}
+
+.featured-project-card .project-card__head {
+  border-bottom: 1px solid #d7e3ee;
+  padding-bottom: 0.6rem;
+}
+
+.featured-project-card .project-number {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.case-study-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  margin-top: 1rem;
+}
+
+.supporting-project-card {
+  border-left-width: 3px;
+  background: #ffffff;
+  opacity: 0.96;
+}
+
+.supporting-project-card .project-summary,
+.supporting-project-card .project-facts dd {
+  font-size: 0.9rem;
+}
+
+.request-types {
+  margin-top: 1rem;
+}
+
+.request-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 230px), 1fr));
+  gap: 0.45rem 1rem;
+  margin-top: 1rem;
+  padding: var(--v2-card-pad);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--secondary-color);
+  border-radius: 8px;
+  background: #f8fbfe;
+}
+
+.request-checklist li {
+  margin-left: 1.1rem;
+}
+
+[data-theme="dark"] .featured-project-card,
+[data-theme="dark"] .supporting-project-card {
+  background: #252525;
+}
+
+[data-theme="dark"] .featured-project-card .project-card__head {
+  border-bottom-color: #385066;
+}
+
+[data-theme="dark"] .request-checklist {
+  background: #252525;
+  border-color: #385066;
+  border-left-color: var(--secondary-color);
+}

--- a/en/about.html
+++ b/en/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>About - Hugo Monteiro | MD/MPH Digital Health Specialist</title>
+    <title>About - Hugo Monteiro | MD/MPH Public Health Intelligence and Digital Transformation</title>
     <meta name="description" content="Professional profile of Hugo Monteiro, a Portuguese MD/MPH and PhD candidate in Health Data Science, with work across public health, digital health, and health data.">
     
     <meta name="author" content="Hugo Monteiro">
@@ -18,7 +18,7 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="profile">
-    <meta property="og:title" content="About Hugo Monteiro - MD/MPH Digital Health Specialist">
+    <meta property="og:title" content="About Hugo Monteiro - MD/MPH Public Health Intelligence and Digital Transformation">
     <meta property="og:description" content="Learn about Hugo Monteiro, a Portuguese MD/MPH and PhD candidate in Health Data Science, dedicated to digital health transformation.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/about.html">
@@ -27,7 +27,7 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="About Hugo Monteiro - MD/MPH Digital Health Specialist">
+    <meta name="twitter:title" content="About Hugo Monteiro - MD/MPH Public Health Intelligence and Digital Transformation">
     <meta name="twitter:description" content="Professional profile of Hugo Monteiro across public health, digital health, and health data.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
@@ -52,7 +52,7 @@
         "name": "Hugo Monteiro",
         "givenName": "Hugo",
         "familyName": "Monteiro",
-        "jobTitle": ["Medical Doctor", "Public Health Physician", "Digital Health Specialist", "PhD Candidate"],
+        "jobTitle": ["Medical Doctor", "Public Health Physician", "Public Health Intelligence and Digital Transformation", "PhD Candidate"],
         "description": "MD/MPH and PhD candidate in Health Data Science, focused on digital transformation of healthcare policy and operations",
         "url": "https://www.hfmonteiro.com",
         "image": "https://www.hfmonteiro.com/assets/img/favicon.png",
@@ -111,7 +111,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">

--- a/en/contact.html
+++ b/en/contact.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Contact - Hugo Monteiro | Professional Channels and Collaboration</title>
-    <meta name="description" content="Professional channels for digital health collaboration, research, consulting, and event participation. Public profiles on LinkedIn and ORCID.">
+    <title>Contact - Hugo Monteiro | Public Health Intelligence Collaboration, Speaking and Training</title>
+    <meta name="description" content="Professional contact for speaking, training, advisory work, research collaboration, screening analytics, surveillance workflows and public health intelligence project review.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Contact Hugo Monteiro - Digital Health Specialist">
-    <meta property="og:description" content="Professional channels for digital health collaboration, research, consulting, and event participation.">
+    <meta property="og:title" content="Contact - Hugo Monteiro | Public Health Intelligence Collaboration, Speaking and Training">
+    <meta property="og:description" content="Professional contact for speaking, training, advisory work, research collaboration, screening analytics, surveillance workflows and public health intelligence project review.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/contact.html">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Contact Hugo Monteiro - Digital Health Specialist">
-    <meta name="twitter:description" content="Professional channels for digital health collaboration, research, consulting, and event participation.">
+    <meta name="twitter:title" content="Contact - Hugo Monteiro | Public Health Intelligence Collaboration, Speaking and Training">
+    <meta name="twitter:description" content="Professional contact for speaking, training, advisory work, research collaboration, screening analytics, surveillance workflows and public health intelligence project review.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -51,7 +51,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">
@@ -155,6 +155,29 @@
                         <p>Digital health strategy development, health system optimization, and policy advisory services.</p>
                     </div>
                 </div>
+            </section>
+
+            <section class="request-guidance" aria-labelledby="request-guidance-heading">
+                <h3 id="request-guidance-heading">What to include in a request</h3>
+                <p>For speaking, training, advisory or project-review requests, please include enough context to assess fit, scope and governance requirements.</p>
+                <div class="opportunities-grid request-types" aria-label="Request types">
+                    <div class="opportunity-item"><h4>Speaking</h4><p>Invited talks, conference sessions or institutional briefings on public health intelligence and digital transformation.</p></div>
+                    <div class="opportunity-item"><h4>Training</h4><p>Workshops or structured sessions for teams working with surveillance, screening analytics, dashboards or health information systems.</p></div>
+                    <div class="opportunity-item"><h4>Advisory</h4><p>Focused advice on public-health intelligence workflows, governance, analytics design or responsible digital transformation.</p></div>
+                    <div class="opportunity-item"><h4>Research collaboration</h4><p>Collaboration where there is a clear institutional, methodological and data-governance fit.</p></div>
+                    <div class="opportunity-item"><h4>Public health intelligence project review</h4><p>Review of dashboards, indicators, data-to-decision workflows, alerting concepts or operational intelligence products.</p></div>
+                    <div class="opportunity-item"><h4>Screening analytics / BI support</h4><p>Support for programme monitoring, exception tracking, process visibility and data-informed improvement.</p></div>
+                    <div class="opportunity-item"><h4>Surveillance or planning workflow support</h4><p>Support for signal detection, surveillance reporting, municipal planning or territorial intelligence workflows.</p></div>
+                </div>
+                <ul class="request-checklist">
+                    <li>Organisation.</li>
+                    <li>Country or health-system context.</li>
+                    <li>Type of request.</li>
+                    <li>Timeline.</li>
+                    <li>Expected output.</li>
+                    <li>Whether data governance, ethics or privacy constraints apply.</li>
+                    <li>Preferred language: English or Portuguese.</li>
+                </ul>
             </section>
 
             <section class="current-affiliations">

--- a/en/experience.html
+++ b/en/experience.html
@@ -49,7 +49,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">

--- a/en/index.html
+++ b/en/index.html
@@ -157,7 +157,7 @@
                     <h3>Surveillance &amp; Signal Detection — EpiSignal</h3>
                     <p>Governed surveillance views that help teams interpret routine data, detect relevant signals, and structure follow-up.</p>
                     <p><strong>Decision problem supported:</strong> When and where should public health teams investigate, prioritise, or escalate an emerging signal?</p>
-                    <a href="/en/projects.html#surveillance-signal-detection" class="card-link">View EpiSignal project</a>
+                    <a href="/en/projects.html#episignal" class="card-link">View EpiSignal project</a>
                 </article>
 
                 <article class="card">

--- a/en/legal.html
+++ b/en/legal.html
@@ -18,7 +18,7 @@
     <a href="#main" class="skip-link">Skip to main content</a>
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
     <nav role="navigation" aria-label="Main navigation">
         <a href="/en/">Home</a>

--- a/en/projects.html
+++ b/en/projects.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Projects - Hugo Monteiro | Public Health, Digital Health and Applied AI Work</title>
-    <meta name="description" content="Selected public-facing project themes by Hugo Monteiro across public health planning, screening dashboards, surveillance reporting, GovTech, interoperability, and applied AI.">
+    <title>Projects - Hugo Monteiro | Public Health Intelligence, Surveillance and Screening Analytics</title>
+    <meta name="description" content="Featured public health intelligence work by Hugo Monteiro across surveillance and signal detection, municipal health planning, screening analytics, health information systems and BI in healthcare.">
     <meta name="author" content="Hugo Monteiro">
     <link rel="canonical" href="https://www.hfmonteiro.com/en/projects.html">
     <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/projects.html">
     <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/projetos.html">
     <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/projects.html">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Projects - Hugo Monteiro | Public Health, Digital Health and Applied AI Work">
-    <meta property="og:description" content="Selected public-facing project themes by Hugo Monteiro across public health planning, screening dashboards, surveillance reporting, GovTech, interoperability, and applied AI.">
+    <meta property="og:title" content="Projects - Hugo Monteiro | Public Health Intelligence, Surveillance and Screening Analytics">
+    <meta property="og:description" content="Featured public health intelligence work by Hugo Monteiro across surveillance and signal detection, municipal health planning, screening analytics, health information systems and BI in healthcare.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
@@ -21,8 +21,8 @@
     <meta property="og:locale" content="en_US">
     <meta property="og:locale:alternate" content="pt_PT">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Projects - Hugo Monteiro | Public Health, Digital Health and Applied AI Work">
-    <meta name="twitter:description" content="Selected public-facing project themes by Hugo Monteiro across public health planning, screening dashboards, surveillance reporting, GovTech, interoperability, and applied AI.">
+    <meta name="twitter:title" content="Projects - Hugo Monteiro | Public Health Intelligence, Surveillance and Screening Analytics">
+    <meta name="twitter:description" content="Featured public health intelligence work by Hugo Monteiro across surveillance and signal detection, municipal health planning, screening analytics, health information systems and BI in healthcare.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
@@ -35,7 +35,7 @@
     <a href="#main" class="skip-link">Skip to main content</a>
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">
@@ -60,178 +60,22 @@
 
     <main role="main" id="main">
         <article class="page-content projects-page">
-            <header class="page-header projects-hero">
-                <div>
-                    <p class="eyebrow">Selected projects</p>
-                    <h2>Projects</h2>
-                    <p class="lead">Applied work across public health, data, digital processes and responsible AI.</p>
-                </div>
-            </header>
-
-            <section class="projects-intro">
-                <p>A selection of applied work across public health, data and digital transformation. The examples are described at a public and aggregate level, focused on the problem, contribution and practical result.</p>
-                <div class="project-themes" aria-label="Project themes">
-                    <span>Public health planning</span>
-                    <span>Data and BI</span>
-                    <span>Digital processes</span>
-                    <span>Governed AI</span>
-                </div>
-            </section>
-
-            <section class="project-index" aria-label="Selected projects">
-                <article class="project-card" id="territorial-public-health-planning">
-                    <div class="project-card__head">
-                        <span class="project-number">01</span>
-                        <p class="project-meta">Public health planning</p>
-                    </div>
-                    <h4>Health Situation Diagnosis and Municipal Health Planning</h4>
-                    <p class="project-summary">Population evidence structured to support local priorities and public-health planning decisions.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Indicators, territory, health needs and operational interpretation for public decision-making.</dd>
-                        </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>A clearer working basis for local discussion without exposing personal or sensitive information.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Public health</span>
-                        <span>Planning</span>
-                        <span>Indicators</span>
-                    </div>
-                </article>
-                <article class="project-card" id="screening-programme-intelligence">
-                    <div class="project-card__head">
-                        <span class="project-number">02</span>
-                        <p class="project-meta">Programme monitoring</p>
-                    </div>
-                    <h4>Screening Programme Dashboards</h4>
-                    <p class="project-summary">Monitoring views that make screening programmes easier to follow, prioritise and manage.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Prioritisation, exceptions, monitoring cadence and rapid performance interpretation.</dd>
-                        </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>Less reliance on ad hoc analysis and better operational visibility.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Dashboards</span>
-                        <span>Screening</span>
-                        <span>Data</span>
-                    </div>
-                </article>
-                <article class="project-card" id="surveillance-signal-detection">
-                    <div class="project-card__head">
-                        <span class="project-number">03</span>
-                        <p class="project-meta">Surveillance and reporting</p>
-                    </div>
-                    <h4>Digital Surveillance Bulletins</h4>
-                    <p class="project-summary">More consistent production of public-health bulletins and recurring communication products.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Data preparation, repeatable routines and clear public-health communication.</dd>
-                        </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>Reduced manual work and greater consistency across periodic publications.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Surveillance</span>
-                        <span>Automation</span>
-                        <span>Reporting</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">04</span>
-                        <p class="project-meta">Administrative digitalisation</p>
-                    </div>
-                    <h4>Sanitary Pool Records</h4>
-                    <p class="project-summary">Moving paper-based administrative processes into records that are easier to consult and audit.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Administrative requirements, traceability, team adoption and document clarity.</dd>
-                        </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>A more transparent workflow with less friction in record management.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>GovTech</span>
-                        <span>Records</span>
-                        <span>Process</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">05</span>
-                        <p class="project-meta">Care pathways</p>
-                    </div>
-                    <h4>ICTUSnet and Pathway Coordination</h4>
-                    <p class="project-summary">Collaborative work around stroke pathways, shared information and coordination between teams.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Interoperability, response times, data quality and stakeholder alignment.</dd>
-                        </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>A clearer shared frame for clinical, operational and technology decisions.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Pathways</span>
-                        <span>Interoperability</span>
-                        <span>Collaboration</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">06</span>
-                        <p class="project-meta">Applied AI and data science</p>
-                    </div>
-                    <h4>AI, NLP and GIS Prototypes</h4>
-                    <p class="project-summary">Practical exploration of AI, text processing and geospatial analysis in public-health problems.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Focus</dt>
-                            <dd>Technical feasibility, operational usefulness, privacy, governance and human review.</dd>
-                        </div>
-                        <div>
-                            <dt>Result</dt>
-                            <dd>Clearer criteria for deciding which ideas should move from prototype to implementation.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>AI</span>
-                        <span>NLP</span>
-                        <span>GIS</span>
-                        <span>Governance</span>
-                    </div>
-                </article>
-            </section>
-
-            <section class="projects-method">
-                <h3>How This Work Is Run</h3>
-                <div class="method-grid">
-                    <div><h4>Decision clarity</h4><p>Start with who decides, at what cadence, and which indicator changes action.</p></div>
-                    <div><h4>Realistic maintenance</h4><p>Prefer solutions teams can update, explain and audit after launch.</p></div>
-                    <div><h4>Visible governance</h4><p>Treat privacy, traceability and human accountability as design requirements.</p></div>
-                </div>
-            </section>
+            <header class="page-header projects-hero"><div><p class="eyebrow">Focused portfolio</p><h2>Projects</h2><p class="lead">Public health intelligence and digital transformation work organised around three flagship lines: detect, plan and improve.</p></div></header>
+            <section class="projects-intro"><p>The examples below are described at a public and aggregate level. The three featured lines show the core portfolio: surveillance and signal detection, territorial planning, and screening programme intelligence. Additional applied work remains available as supporting evidence of range and continuity.</p><div class="project-themes" aria-label="Project themes"><span>Surveillance and signal detection</span><span>Municipal health planning</span><span>Screening analytics</span><span>Governed BI</span></div></section>
+            <section class="featured-work" aria-labelledby="featured-work-heading"><p class="eyebrow">Featured work</p><h3 id="featured-work-heading">Featured Work</h3><div class="featured-project-grid">
+                <article class="project-card featured-project-card" id="episignal"><div class="project-card__head"><span class="project-number">Detect</span><p class="project-meta">Surveillance and signal detection</p></div><h4>EpiSignal — Surveillance and Signal Detection</h4><p class="project-summary">A public health intelligence prototype/demonstrator for structuring data-to-signal workflows, prioritisation, uncertainty, alerting concepts and human review.</p><dl class="project-facts case-study-grid"><div><dt>Problem</dt><dd>Surveillance teams often need to interpret fragmented routine data and observations before deciding what deserves review, escalation or monitoring.</dd></div><div><dt>Context</dt><dd>Public health surveillance, epidemic intelligence, operational alerting, uncertainty and review workflows.</dd></div><div><dt>My role</dt><dd>Framing the intelligence workflow as a prototype/demonstrator, with emphasis on safe interpretation and operational usefulness.</dd></div><div><dt>Methods/tools</dt><dd>Data-to-signal logic, prioritisation criteria, review queues, alerting concepts and dashboard/reporting views where appropriate.</dd></div><div><dt>Governance and human review</dt><dd>Human-in-the-loop review, traceability, privacy boundaries, uncertainty handling and accountable escalation are treated as design requirements.</dd></div><div><dt>Output</dt><dd>A reviewable public-health intelligence concept that helps structure how signals are detected, prioritised and discussed.</dd></div><div><dt>What it demonstrates</dt><dd>The ability to translate surveillance information into governed, operationally useful intelligence without claiming production use.</dd></div><div><dt>Transferability</dt><dd>Relevant to surveillance units, local public-health teams, epidemic intelligence cells and emergency preparedness workflows.</dd></div></dl><div class="project-tags"><span>Surveillance</span><span>Epidemic intelligence</span><span>Signal detection</span><span>Human review</span></div></article>
+                <article class="project-card featured-project-card" id="territorial-public-health-planning"><div class="project-card__head"><span class="project-number">Plan</span><p class="project-meta">Territorial public health intelligence</p></div><h4>ULS PLS Digital / Municipal Health Planning</h4><p class="project-summary">Digital Local Health Plan and municipal planning work that helps structure indicators, population needs, local priorities and planning workflows.</p><dl class="project-facts case-study-grid"><div><dt>Problem</dt><dd>Local planning depends on coherent population evidence, but indicators, territorial needs and decision cycles can be difficult to align.</dd></div><div><dt>Context</dt><dd>Health situation diagnosis, municipal health planning, ULS decision support and public-health planning workflows.</dd></div><div><dt>My role</dt><dd>Helping structure indicators, interpretation, planning logic and decision-support views for territorial public-health discussion.</dd></div><div><dt>Methods/tools</dt><dd>Indicator organisation, population-needs framing, territorial analysis, dashboard concepts and planning-oriented documentation.</dd></div><div><dt>Governance and data protection</dt><dd>Outputs are kept public-safe and aggregate, with clear interpretation boundaries and attention to data protection requirements.</dd></div><div><dt>Output</dt><dd>A clearer working basis for municipal and ULS planning discussions without exposing personal or sensitive information.</dd></div><div><dt>What it demonstrates</dt><dd>Territorial public-health intelligence: turning indicators into a governed basis for local priorities and planning decisions.</dd></div><div><dt>Transferability</dt><dd>Applicable to local health plans, municipal health strategies, ULS planning cycles and population-health prioritisation.</dd></div></dl><div class="project-tags"><span>Planning</span><span>Indicators</span><span>Municipal health</span><span>Decision support</span></div></article>
+                <article class="project-card featured-project-card" id="screening-programme-intelligence"><div class="project-card__head"><span class="project-number">Improve</span><p class="project-meta">Screening programme intelligence</p></div><h4>Screening Dashboards — Programme Intelligence</h4><p class="project-summary">Operational BI and dashboard work for screening programme monitoring, prioritisation, exception tracking and data-informed improvement.</p><dl class="project-facts case-study-grid"><div><dt>Problem</dt><dd>Screening programmes need visibility over participation, workflow delays, exceptions and follow-up so teams can prioritise action.</dd></div><div><dt>Context</dt><dd>Programme monitoring, especially cancer and colorectal screening work where supported by public research outputs.</dd></div><div><dt>My role</dt><dd>BI/dashboard design, process interpretation, prioritisation logic and connection to research on screening analytics and process mining.</dd></div><div><dt>Methods/tools</dt><dd>Dashboards, programme indicators, process-mining concepts, exception tracking and operational monitoring views.</dd></div><div><dt>Governance and data protection</dt><dd>Aggregate and privacy-aware monitoring, with attention to appropriate access, interpretation and responsible use of programme data.</dd></div><div><dt>Output</dt><dd>Monitoring views that create operational visibility and provide a basis for programme review and improvement conversations.</dd></div><div><dt>What it demonstrates</dt><dd>The translation of screening data into practical operational intelligence, linked to published work on screening and process mining.</dd></div><div><dt>Transferability</dt><dd>Relevant to population screening programmes, monitoring units, quality-improvement teams and healthcare BI teams.</dd></div></dl><div class="project-tags"><span>Screening</span><span>Dashboards</span><span>Process mining</span><span>BI in healthcare</span></div></article>
+            </div></section>
+            <section class="additional-applied-work" aria-labelledby="additional-work-heading"><p class="eyebrow">Supporting projects</p><h3 id="additional-work-heading">Additional Applied Work</h3><p class="section-note">These projects are kept as supporting evidence. They show range across public-health reporting, administrative digitalisation, pathway coordination and governed prototypes, but they are intentionally lighter than the three flagship lines above.</p><div class="supporting-project-grid">
+                <article class="project-card supporting-project-card" id="digital-surveillance-bulletins"><div class="project-card__head"><span class="project-number">01</span><p class="project-meta">Surveillance and reporting</p></div><h4>Digital Surveillance Bulletins</h4><p class="project-summary">More consistent production of public-health bulletins and recurring communication products.</p><dl class="project-facts"><div><dt>Focus</dt><dd>Data preparation, repeatable routines and clear public-health communication.</dd></div><div><dt>Result</dt><dd>Reduced manual work and greater consistency across periodic publications.</dd></div></dl><div class="project-tags"><span>Surveillance</span><span>Automation</span><span>Reporting</span></div></article>
+                <article class="project-card supporting-project-card" id="sanitary-pool-records"><div class="project-card__head"><span class="project-number">02</span><p class="project-meta">Administrative digitalisation</p></div><h4>Sanitary Pool Records</h4><p class="project-summary">Moving paper-based administrative processes into records that are easier to consult and audit.</p><dl class="project-facts"><div><dt>Focus</dt><dd>Administrative requirements, traceability, team adoption and document clarity.</dd></div><div><dt>Result</dt><dd>A more transparent workflow with less friction in record management.</dd></div></dl><div class="project-tags"><span>GovTech</span><span>Records</span><span>Process</span></div></article>
+                <article class="project-card supporting-project-card" id="ictusnet-pathway-coordination"><div class="project-card__head"><span class="project-number">03</span><p class="project-meta">Care pathways</p></div><h4>ICTUSnet and Pathway Coordination</h4><p class="project-summary">Collaborative work around stroke pathways, shared information and coordination between teams.</p><dl class="project-facts"><div><dt>Focus</dt><dd>Interoperability, response times, data quality and stakeholder alignment.</dd></div><div><dt>Result</dt><dd>A clearer shared frame for clinical, operational and technology decisions.</dd></div></dl><div class="project-tags"><span>Pathways</span><span>Interoperability</span><span>Collaboration</span></div></article>
+                <article class="project-card supporting-project-card" id="ai-nlp-gis-prototypes"><div class="project-card__head"><span class="project-number">04</span><p class="project-meta">Applied AI and data science</p></div><h4>AI, NLP and GIS Prototypes</h4><p class="project-summary">Practical exploration of AI, text processing and geospatial analysis in public-health problems.</p><dl class="project-facts"><div><dt>Focus</dt><dd>Technical feasibility, operational usefulness, privacy, governance and human review.</dd></div><div><dt>Result</dt><dd>Clearer criteria for deciding which ideas should move from prototype to implementation.</dd></div></dl><div class="project-tags"><span>AI</span><span>NLP</span><span>GIS</span><span>Governance</span></div></article>
+            </div></section>
+            <section class="projects-method"><h3>How This Work Is Run</h3><div class="method-grid"><div><h4>Decision clarity</h4><p>Start with who decides, at what cadence, and which indicator changes action.</p></div><div><h4>Realistic maintenance</h4><p>Prefer solutions teams can update, explain and audit after launch.</p></div><div><h4>Visible governance</h4><p>Treat privacy, traceability and human accountability as design requirements.</p></div></div></section>
         </article>
-    </main>
-
-    <footer>
+    </main>    <footer>
         <p>&copy; <span id="current-year"></span> Hugo Monteiro. 
             <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener" class="orcid-link">ORCID</a> | 
             <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener">LinkedIn</a> | 

--- a/en/publications.html
+++ b/en/publications.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Publications - Hugo Monteiro | Digital Health Research Publications</title>
-    <meta name="description" content="Research publications by Hugo Monteiro in digital health, public health systems, and health data science, regularly updated from ORCID.">
+    <title>Publications - Hugo Monteiro | Screening Analytics, ERIMS and Health Data Science</title>
+    <meta name="description" content="Publications by Hugo Monteiro on screening analytics, process mining, emergency information management systems, digital health, health data science and public health intelligence, updated from ORCID.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Publications - Hugo Monteiro | Digital Health Research Publications">
-    <meta property="og:description" content="Research publications by Hugo Monteiro in digital health, public health systems, and health data science, regularly updated from ORCID.">
+    <meta property="og:title" content="Publications - Hugo Monteiro | Screening Analytics, ERIMS and Health Data Science">
+    <meta property="og:description" content="Publications by Hugo Monteiro on screening analytics, process mining, emergency information management systems, digital health, health data science and public health intelligence, updated from ORCID.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/publications.html">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Publications - Hugo Monteiro | Digital Health Research Publications">
-    <meta name="twitter:description" content="Research publications by Hugo Monteiro in digital health, public health systems, and health data science, regularly updated from ORCID.">
+    <meta name="twitter:title" content="Publications - Hugo Monteiro | Screening Analytics, ERIMS and Health Data Science">
+    <meta name="twitter:description" content="Publications by Hugo Monteiro on screening analytics, process mining, emergency information management systems, digital health, health data science and public health intelligence, updated from ORCID.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security headers should be sent by the server/CDN -->
@@ -49,7 +49,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">

--- a/en/research.html
+++ b/en/research.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Research - Hugo Monteiro | Digital Health & Public Health Research</title>
-    <meta name="description" content="Explore Hugo Monteiro's research interests in digital health systems, screening programs, health information systems, and data visualization in healthcare.">
+    <title>Research - Hugo Monteiro | Public Health Intelligence, Screening Analytics and ERIMS</title>
+    <meta name="description" content="Research interests by Hugo Monteiro in screening analytics, process mining, ERIMS, health information systems, emergency information management and population health analytics.">
     
     <meta name="author" content="Hugo Monteiro">
     
@@ -18,8 +18,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Research - Hugo Monteiro | Digital Health & Public Health Research">
-    <meta property="og:description" content="Explore Hugo Monteiro's research interests in digital health systems, screening programs, health information systems, and data visualization in healthcare.">
+    <meta property="og:title" content="Research - Hugo Monteiro | Public Health Intelligence, Screening Analytics and ERIMS">
+    <meta property="og:description" content="Research interests by Hugo Monteiro in screening analytics, process mining, ERIMS, health information systems, emergency information management and population health analytics.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/en/research.html">
     <meta property="og:locale" content="en_US">
@@ -27,8 +27,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Research - Hugo Monteiro | Digital Health & Public Health Research">
-    <meta name="twitter:description" content="Explore Hugo Monteiro's research interests in digital health systems, screening programs, health information systems, and data visualization in healthcare.">
+    <meta name="twitter:title" content="Research - Hugo Monteiro | Public Health Intelligence, Screening Analytics and ERIMS">
+    <meta name="twitter:description" content="Research interests by Hugo Monteiro in screening analytics, process mining, ERIMS, health information systems, emergency information management and population health analytics.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security headers should be sent by the server/CDN -->
@@ -49,7 +49,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">

--- a/en/speaking-training.html
+++ b/en/speaking-training.html
@@ -34,7 +34,7 @@
     <a href="#main" class="skip-link">Skip to main content</a>
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Digital Health Specialist</p>
+        <p class="subtitle">MD/MPH | Public Health Intelligence &amp; Digital Transformation</p>
     </header>
 
     <nav role="navigation" aria-label="Main navigation">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "hfmonteiro-webpage",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hfmonteiro-webpage",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hfmonteiro-webpage",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static bilingual professional portfolio website for Hugo Monteiro.",
+  "scripts": {
+    "validate": "node scripts/validate_site.js",
+    "serve": "python3 -m http.server 4173",
+    "smoke": "playwright test scripts/smoke_site.spec.js --reporter=list",
+    "test": "npm run validate"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
+  }
+}

--- a/pt/contacto.html
+++ b/pt/contacto.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Contacto - Hugo Monteiro | Canais Profissionais e Colaboração</title>
-    <meta name="description" content="Canais profissionais para colaboração em saúde digital, investigação, consultoria e participação em eventos. Perfis públicos no LinkedIn e ORCID.">
+    <title>Contacto - Hugo Monteiro | Colaboração em Inteligência em Saúde Pública, Palestras e Formação</title>
+    <meta name="description" content="Contacto profissional para palestras, formação, assessoria, colaboração em investigação, análise de rastreios, fluxos de vigilância e revisão de projetos de inteligência em saúde pública.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Contacto Hugo Monteiro - Especialista em Saúde Digital">
-    <meta property="og:description" content="Canais profissionais para colaboração em saúde digital, investigação, consultoria e participação em eventos.">
+    <meta property="og:title" content="Contacto - Hugo Monteiro | Colaboração em Inteligência em Saúde Pública, Palestras e Formação">
+    <meta property="og:description" content="Contacto profissional para palestras, formação, assessoria, colaboração em investigação, análise de rastreios, fluxos de vigilância e revisão de projetos de inteligência em saúde pública.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/contacto.html">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Contacto Hugo Monteiro - Especialista em Saúde Digital">
-    <meta name="twitter:description" content="Canais profissionais para colaboração em saúde digital, investigação, consultoria e participação em eventos.">
+    <meta name="twitter:title" content="Contacto - Hugo Monteiro | Colaboração em Inteligência em Saúde Pública, Palestras e Formação">
+    <meta name="twitter:description" content="Contacto profissional para palestras, formação, assessoria, colaboração em investigação, análise de rastreios, fluxos de vigilância e revisão de projetos de inteligência em saúde pública.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -50,7 +50,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">
@@ -154,6 +154,29 @@
                         <p>Desenvolvimento de estratégias de saúde digital, otimização de sistemas de saúde e serviços de consultoria em políticas.</p>
                     </div>
                 </div>
+            </section>
+
+            <section class="request-guidance" aria-labelledby="request-guidance-heading">
+                <h3 id="request-guidance-heading">O que incluir num pedido</h3>
+                <p>Para pedidos de palestra, formação, assessoria ou revisão de projeto, inclua contexto suficiente para avaliar alinhamento, âmbito e requisitos de governação.</p>
+                <div class="opportunities-grid request-types" aria-label="Tipos de pedido">
+                    <div class="opportunity-item"><h4>Palestra</h4><p>Apresentações convidadas, sessões em conferências ou briefings institucionais sobre inteligência em saúde pública e transformação digital.</p></div>
+                    <div class="opportunity-item"><h4>Formação</h4><p>Workshops ou sessões estruturadas para equipas que trabalham com vigilância, análise de rastreios, dashboards ou sistemas de informação em saúde.</p></div>
+                    <div class="opportunity-item"><h4>Assessoria</h4><p>Aconselhamento focado em fluxos de inteligência em saúde pública, governação, desenho analítico ou transformação digital responsável.</p></div>
+                    <div class="opportunity-item"><h4>Colaboração em investigação</h4><p>Colaboração quando exista enquadramento institucional, metodológico e de governação de dados claro.</p></div>
+                    <div class="opportunity-item"><h4>Revisão de projeto de inteligência em saúde pública</h4><p>Revisão de dashboards, indicadores, fluxos de dados-para-decisão, conceitos de alerta ou produtos de inteligência operacional.</p></div>
+                    <div class="opportunity-item"><h4>Apoio em análise de rastreios / BI</h4><p>Apoio à monitorização de programas, seguimento de exceções, visibilidade de processos e melhoria informada por dados.</p></div>
+                    <div class="opportunity-item"><h4>Apoio a fluxos de vigilância ou planeamento</h4><p>Apoio a deteção de sinais, comunicação de vigilância, planeamento municipal ou fluxos de inteligência territorial.</p></div>
+                </div>
+                <ul class="request-checklist">
+                    <li>Organização.</li>
+                    <li>País ou contexto do sistema de saúde.</li>
+                    <li>Tipo de pedido.</li>
+                    <li>Calendário previsto.</li>
+                    <li>Resultado esperado.</li>
+                    <li>Se existem restrições de governação de dados, ética ou privacidade.</li>
+                    <li>Idioma preferido: inglês ou português.</li>
+                </ul>
             </section>
 
             <section class="current-affiliations">

--- a/pt/experiencia.html
+++ b/pt/experiencia.html
@@ -50,7 +50,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">

--- a/pt/formacao-palestras.html
+++ b/pt/formacao-palestras.html
@@ -34,7 +34,7 @@
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">

--- a/pt/index.html
+++ b/pt/index.html
@@ -140,21 +140,21 @@
             
             <div class="cards-grid">
                 <article class="card">
-                    <h3>Surveillance &amp; Signal Detection — EpiSignal</h3>
+                    <h3>Vigilância e Deteção de Sinais — EpiSignal</h3>
                     <p>Vistas de vigilância governadas que ajudam equipas a interpretar dados de rotina, detetar sinais relevantes e estruturar seguimento.</p>
                     <p><strong>Problema de decisão apoiado:</strong> Quando e onde devem as equipas de saúde pública investigar, priorizar ou escalar um sinal emergente?</p>
-                    <a href="/pt/projetos.html#surveillance-signal-detection" class="card-link">Ver projeto EpiSignal</a>
+                    <a href="/pt/projetos.html#episignal" class="card-link">Ver projeto EpiSignal</a>
                 </article>
 
                 <article class="card">
-                    <h3>Territorial Public Health Planning — ULS PLS Digital / Municipal</h3>
+                    <h3>Planeamento Territorial em Saúde Pública — ULS PLS Digital / Municipal</h3>
                     <p>Apoio ao planeamento territorial que organiza indicadores, necessidades e prioridades numa base comum de evidência.</p>
                     <p><strong>Problema de decisão apoiado:</strong> Que prioridades locais devem orientar o planeamento em saúde pública entre municípios e serviços?</p>
                     <a href="/pt/projetos.html#territorial-public-health-planning" class="card-link">Ver projeto de planeamento</a>
                 </article>
 
                 <article class="card">
-                    <h3>Screening Programme Intelligence — Screening Dashboards</h3>
+                    <h3>Inteligência para Programas de Rastreio — Dashboards de Rastreio</h3>
                     <p>Dashboards de inteligência de programas que tornam a atividade de rastreio mais fácil de monitorizar, priorizar e melhorar.</p>
                     <p><strong>Problema de decisão apoiado:</strong> Que bloqueios, exceções ou coortes precisam de atenção para manter os percursos de rastreio a avançar?</p>
                     <a href="/pt/projetos.html#screening-programme-intelligence" class="card-link">Ver dashboards de rastreio</a>

--- a/pt/investigacao.html
+++ b/pt/investigacao.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública</title>
-    <meta name="description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
+    <title>Investigação - Hugo Monteiro | Inteligência em Saúde Pública, Rastreios e ERIMS</title>
+    <meta name="description" content="Interesses de investigação de Hugo Monteiro em análise de rastreios, process mining, ERIMS, sistemas de informação em saúde, gestão de informação em emergência e análise de saúde populacional.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública">
-    <meta property="og:description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
+    <meta property="og:title" content="Investigação - Hugo Monteiro | Inteligência em Saúde Pública, Rastreios e ERIMS">
+    <meta property="og:description" content="Interesses de investigação de Hugo Monteiro em análise de rastreios, process mining, ERIMS, sistemas de informação em saúde, gestão de informação em emergência e análise de saúde populacional.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/investigacao.html">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Investigação - Hugo Monteiro | Investigação em Saúde Digital & Saúde Pública">
-    <meta name="twitter:description" content="Explore os interesses de investigação de Hugo Monteiro em sistemas de saúde digital, programas de rastreio, sistemas de informação em saúde e visualização de dados em saúde.">
+    <meta name="twitter:title" content="Investigação - Hugo Monteiro | Inteligência em Saúde Pública, Rastreios e ERIMS">
+    <meta name="twitter:description" content="Interesses de investigação de Hugo Monteiro em análise de rastreios, process mining, ERIMS, sistemas de informação em saúde, gestão de informação em emergência e análise de saúde populacional.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -50,7 +50,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">

--- a/pt/legal.html
+++ b/pt/legal.html
@@ -18,7 +18,7 @@
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
     <nav role="navigation" aria-label="Navegação principal">
         <a href="/pt/">Início</a>

--- a/pt/projetos.html
+++ b/pt/projetos.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Projetos - Hugo Monteiro | Saúde Pública, Saúde Digital e IA Aplicada</title>
-    <meta name="description" content="Projetos e áreas de trabalho selecionadas de Hugo Monteiro em planeamento em saúde pública, dashboards de rastreio, vigilância, GovTech, interoperabilidade e IA aplicada.">
+    <title>Projetos - Hugo Monteiro | Inteligência em Saúde Pública, Vigilância e Rastreios</title>
+    <meta name="description" content="Trabalho destacado em inteligência em saúde pública de Hugo Monteiro em vigilância e deteção de sinais, planeamento municipal em saúde, análise de rastreios, sistemas de informação e BI em saúde.">
     <meta name="author" content="Hugo Monteiro">
     <link rel="canonical" href="https://www.hfmonteiro.com/pt/projetos.html">
     <link rel="alternate" hreflang="en" href="https://www.hfmonteiro.com/en/projects.html">
     <link rel="alternate" hreflang="pt-PT" href="https://www.hfmonteiro.com/pt/projetos.html">
     <link rel="alternate" hreflang="x-default" href="https://www.hfmonteiro.com/en/projects.html">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Projetos - Hugo Monteiro | Saúde Pública, Saúde Digital e IA Aplicada">
-    <meta property="og:description" content="Projetos e áreas de trabalho selecionadas de Hugo Monteiro em planeamento em saúde pública, dashboards de rastreio, vigilância, GovTech, interoperabilidade e IA aplicada.">
+    <meta property="og:title" content="Projetos - Hugo Monteiro | Inteligência em Saúde Pública, Vigilância e Rastreios">
+    <meta property="og:description" content="Trabalho destacado em inteligência em saúde pública de Hugo Monteiro em vigilância e deteção de sinais, planeamento municipal em saúde, análise de rastreios, sistemas de informação e BI em saúde.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
@@ -21,8 +21,8 @@
     <meta property="og:locale" content="pt_PT">
     <meta property="og:locale:alternate" content="en_US">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Projetos - Hugo Monteiro | Saúde Pública, Saúde Digital e IA Aplicada">
-    <meta name="twitter:description" content="Projetos e áreas de trabalho selecionadas de Hugo Monteiro em planeamento em saúde pública, dashboards de rastreio, vigilância, GovTech, interoperabilidade e IA aplicada.">
+    <meta name="twitter:title" content="Projetos - Hugo Monteiro | Inteligência em Saúde Pública, Vigilância e Rastreios">
+    <meta name="twitter:description" content="Trabalho destacado em inteligência em saúde pública de Hugo Monteiro em vigilância e deteção de sinais, planeamento municipal em saúde, análise de rastreios, sistemas de informação e BI em saúde.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/projects-og.png">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" type="image/svg+xml" href="/assets/img/favicon.svg">
@@ -35,7 +35,7 @@
     <a href="#main" class="skip-link">Saltar para o conteúdo principal</a>
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">
@@ -60,178 +60,22 @@
 
     <main role="main" id="main">
         <article class="page-content projects-page">
-            <header class="page-header projects-hero">
-                <div>
-                    <p class="eyebrow">Projetos selecionados</p>
-                    <h2>Projetos</h2>
-                    <p class="lead">Trabalho aplicado em saúde pública, dados, processos digitais e IA responsável.</p>
-                </div>
-            </header>
-
-            <section class="projects-intro">
-                <p>Uma seleção de trabalho aplicado em saúde pública, dados e transformação digital. Os exemplos são descritos de forma pública e agregada, com foco no problema, no contributo e no resultado prático.</p>
-                <div class="project-themes" aria-label="Temas dos projetos">
-                    <span>Planeamento em saúde pública</span>
-                    <span>Dados e BI</span>
-                    <span>Processos digitais</span>
-                    <span>IA com governação</span>
-                </div>
-            </section>
-
-            <section class="project-index" aria-label="Projetos selecionados">
-                <article class="project-card" id="territorial-public-health-planning">
-                    <div class="project-card__head">
-                        <span class="project-number">01</span>
-                        <p class="project-meta">Planeamento em saúde pública</p>
-                    </div>
-                    <h4>Diagnóstico de Situação de Saúde e Planeamento Municipal</h4>
-                    <p class="project-summary">Organização de evidência populacional para apoiar prioridades locais e decisões de planeamento.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Indicadores, território, necessidades de saúde e leitura operacional para decisão pública.</dd>
-                        </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Base de trabalho clara para discussão local, sem expor dados pessoais ou informação sensível.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Saúde pública</span>
-                        <span>Planeamento</span>
-                        <span>Indicadores</span>
-                    </div>
-                </article>
-                <article class="project-card" id="screening-programme-intelligence">
-                    <div class="project-card__head">
-                        <span class="project-number">02</span>
-                        <p class="project-meta">Monitorização de programas</p>
-                    </div>
-                    <h4>Dashboards de Programas de Rastreio</h4>
-                    <p class="project-summary">Vistas de acompanhamento para tornar programas de rastreio mais fáceis de monitorizar e gerir.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Priorização, exceções, cadência de acompanhamento e leitura rápida de desempenho.</dd>
-                        </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Menos dependência de análises avulsas e melhor visibilidade operacional.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Dashboards</span>
-                        <span>Rastreios</span>
-                        <span>Dados</span>
-                    </div>
-                </article>
-                <article class="project-card" id="surveillance-signal-detection">
-                    <div class="project-card__head">
-                        <span class="project-number">03</span>
-                        <p class="project-meta">Vigilância e reporte</p>
-                    </div>
-                    <h4>Boletins de Vigilância Digitais</h4>
-                    <p class="project-summary">Produção mais consistente de boletins e produtos periódicos de comunicação em saúde pública.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Preparação de dados, rotinas repetíveis e clareza de comunicação.</dd>
-                        </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Redução de trabalho manual e maior consistência entre publicações periódicas.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Vigilância</span>
-                        <span>Automação</span>
-                        <span>Reporte</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">04</span>
-                        <p class="project-meta">Digitalização administrativa</p>
-                    </div>
-                    <h4>Registos Sanitários de Piscinas</h4>
-                    <p class="project-summary">Transição de processos em papel para registos digitais mais simples de consultar e auditar.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Requisitos administrativos, rastreabilidade, adoção pelas equipas e clareza documental.</dd>
-                        </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Fluxo de trabalho mais transparente e menor fricção na gestão dos registos.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>GovTech</span>
-                        <span>Registos</span>
-                        <span>Processos</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">05</span>
-                        <p class="project-meta">Percursos assistenciais</p>
-                    </div>
-                    <h4>ICTUSnet e Coordenação de Percursos</h4>
-                    <p class="project-summary">Trabalho colaborativo em torno de percursos de AVC, informação partilhada e coordenação entre equipas.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Interoperabilidade, tempos de resposta, qualidade dos dados e alinhamento entre stakeholders.</dd>
-                        </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Melhor enquadramento comum para decisões clínicas, operacionais e tecnológicas.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>Percursos</span>
-                        <span>Interoperabilidade</span>
-                        <span>Colaboração</span>
-                    </div>
-                </article>
-                <article class="project-card">
-                    <div class="project-card__head">
-                        <span class="project-number">06</span>
-                        <p class="project-meta">IA e ciência de dados aplicada</p>
-                    </div>
-                    <h4>Protótipos com IA, NLP e GIS</h4>
-                    <p class="project-summary">Exploração prática de IA, processamento de texto e análise geográfica em problemas de saúde pública.</p>
-                    <dl class="project-facts">
-                        <div>
-                            <dt>Foco</dt>
-                            <dd>Viabilidade técnica, utilidade operacional, privacidade, governação e revisão humana.</dd>
-                        </div>
-                        <div>
-                            <dt>Resultado</dt>
-                            <dd>Critérios mais claros para decidir que ideias devem passar de protótipo a implementação.</dd>
-                        </div>
-                    </dl>
-                    <div class="project-tags">
-                        <span>IA</span>
-                        <span>NLP</span>
-                        <span>GIS</span>
-                        <span>Governação</span>
-                    </div>
-                </article>
-            </section>
-
-            <section class="projects-method">
-                <h3>Como estes projetos são trabalhados</h3>
-                <div class="method-grid">
-                    <div><h4>Clareza da decisão</h4><p>Começar por quem decide, com que cadência e que indicador muda a ação.</p></div>
-                    <div><h4>Manutenção realista</h4><p>Preferir soluções que as equipas conseguem atualizar, explicar e auditar.</p></div>
-                    <div><h4>Governação visível</h4><p>Tratar privacidade, rastreabilidade e responsabilidade humana como requisitos de desenho.</p></div>
-                </div>
-            </section>
+            <header class="page-header projects-hero"><div><p class="eyebrow">Portefólio focado</p><h2>Projetos</h2><p class="lead">Trabalho em inteligência em saúde pública e transformação digital organizado em três linhas de referência: detetar, planear e melhorar.</p></div></header>
+            <section class="projects-intro"><p>Os exemplos abaixo são descritos a nível público e agregado. As três linhas em destaque mostram o núcleo do portefólio: vigilância e deteção de sinais, planeamento territorial e inteligência para programas de rastreio. O trabalho aplicado adicional mantém-se disponível como evidência de alcance e continuidade.</p><div class="project-themes" aria-label="Project themes"><span>Vigilância e deteção de sinais</span><span>Planeamento municipal em saúde</span><span>Análise de rastreios</span><span>BI governado</span></div></section>
+            <section class="featured-work" aria-labelledby="featured-work-heading"><p class="eyebrow">Trabalho em destaque</p><h3 id="featured-work-heading">Trabalho em Destaque</h3><div class="featured-project-grid">
+                <article class="project-card featured-project-card" id="episignal"><div class="project-card__head"><span class="project-number">Detetar</span><p class="project-meta">Vigilância e deteção de sinais</p></div><h4>EpiSignal — Vigilância e Deteção de Sinais</h4><p class="project-summary">Protótipo/demonstrador de inteligência em saúde pública para estruturar fluxos de dados-para-sinal, priorização, incerteza, conceitos de alerta e revisão humana.</p><dl class="project-facts case-study-grid"><div><dt>Problema</dt><dd>As equipas de vigilância precisam frequentemente de interpretar dados de rotina e observações fragmentadas antes de decidir o que merece revisão, escalamento ou monitorização.</dd></div><div><dt>Contexto</dt><dd>Vigilância em saúde pública, inteligência epidémica, alertas operacionais, incerteza e fluxos de revisão.</dd></div><div><dt>O meu papel</dt><dd>Enquadramento do fluxo de inteligência como protótipo/demonstrador, com ênfase em interpretação segura e utilidade operacional.</dd></div><div><dt>Métodos/ferramentas</dt><dd>Lógica de dados-para-sinal, critérios de priorização, filas de revisão, conceitos de alerta e vistas de dashboard/relatório quando adequado.</dd></div><div><dt>Governação e revisão humana</dt><dd>Revisão humana, rastreabilidade, limites de privacidade, tratamento da incerteza e escalamento responsável são requisitos de desenho.</dd></div><div><dt>Resultado</dt><dd>Um conceito revisto de inteligência em saúde pública que ajuda a estruturar como os sinais são detetados, priorizados e discutidos.</dd></div><div><dt>O que demonstra</dt><dd>A capacidade de traduzir informação de vigilância em inteligência governada e operacionalmente útil, sem reivindicar uso em produção.</dd></div><div><dt>Transferibilidade</dt><dd>Relevante para unidades de vigilância, equipas locais de saúde pública, células de inteligência epidémica e fluxos de preparação para emergências.</dd></div></dl><div class="project-tags"><span>Vigilância</span><span>Inteligência epidémica</span><span>Deteção de sinais</span><span>Revisão humana</span></div></article>
+                <article class="project-card featured-project-card" id="territorial-public-health-planning"><div class="project-card__head"><span class="project-number">Planear</span><p class="project-meta">Inteligência territorial em saúde pública</p></div><h4>ULS PLS Digital / Planeamento Municipal em Saúde</h4><p class="project-summary">Trabalho de Plano Local de Saúde digital e planeamento municipal que ajuda a estruturar indicadores, necessidades da população, prioridades locais e fluxos de planeamento.</p><dl class="project-facts case-study-grid"><div><dt>Problema</dt><dd>O planeamento local depende de evidência populacional coerente, mas indicadores, necessidades territoriais e ciclos de decisão podem ser difíceis de alinhar.</dd></div><div><dt>Contexto</dt><dd>Diagnóstico de situação de saúde, planeamento municipal em saúde, apoio à decisão da ULS e fluxos de planeamento em saúde pública.</dd></div><div><dt>O meu papel</dt><dd>Apoio à estruturação de indicadores, interpretação, lógica de planeamento e vistas de apoio à decisão para discussão territorial em saúde pública.</dd></div><div><dt>Métodos/ferramentas</dt><dd>Organização de indicadores, enquadramento de necessidades populacionais, análise territorial, conceitos de dashboard e documentação orientada para planeamento.</dd></div><div><dt>Governação e proteção de dados</dt><dd>Os resultados são mantidos agregados e seguros para divulgação pública, com limites claros de interpretação e atenção a requisitos de proteção de dados.</dd></div><div><dt>Resultado</dt><dd>Uma base de trabalho mais clara para discussões municipais e da ULS sem expor informação pessoal ou sensível.</dd></div><div><dt>O que demonstra</dt><dd>Inteligência territorial em saúde pública: transformar indicadores numa base governada para prioridades locais e decisões de planeamento.</dd></div><div><dt>Transferibilidade</dt><dd>Aplicável a planos locais de saúde, estratégias municipais de saúde, ciclos de planeamento da ULS e priorização em saúde populacional.</dd></div></dl><div class="project-tags"><span>Planeamento</span><span>Indicadores</span><span>Saúde municipal</span><span>Apoio à decisão</span></div></article>
+                <article class="project-card featured-project-card" id="screening-programme-intelligence"><div class="project-card__head"><span class="project-number">Melhorar</span><p class="project-meta">Inteligência para programas de rastreio</p></div><h4>Dashboards de Rastreio — Inteligência de Programa</h4><p class="project-summary">Trabalho de BI operacional e dashboards para monitorização de programas de rastreio, priorização, acompanhamento de exceções e melhoria informada por dados.</p><dl class="project-facts case-study-grid"><div><dt>Problema</dt><dd>Os programas de rastreio precisam de visibilidade sobre participação, atrasos de processo, exceções e seguimento para que as equipas possam priorizar ação.</dd></div><div><dt>Contexto</dt><dd>Monitorização de programas, especialmente trabalho em rastreio oncológico e colorretal quando suportado por produção científica pública.</dd></div><div><dt>O meu papel</dt><dd>Desenho de BI/dashboard, interpretação de processos, lógica de priorização e ligação à investigação em análise de rastreios e process mining.</dd></div><div><dt>Métodos/ferramentas</dt><dd>Dashboards, indicadores de programa, conceitos de process mining, acompanhamento de exceções e vistas de monitorização operacional.</dd></div><div><dt>Governação e proteção de dados</dt><dd>Monitorização agregada e consciente da privacidade, com atenção a acesso apropriado, interpretação e uso responsável dos dados do programa.</dd></div><div><dt>Resultado</dt><dd>Vistas de monitorização que criam visibilidade operacional e fornecem uma base para revisão do programa e conversas de melhoria.</dd></div><div><dt>O que demonstra</dt><dd>A tradução de dados de rastreio em inteligência operacional prática, ligada a trabalho publicado sobre rastreio e process mining.</dd></div><div><dt>Transferibilidade</dt><dd>Relevante para programas de rastreio populacional, unidades de monitorização, equipas de melhoria da qualidade e equipas de BI em saúde.</dd></div></dl><div class="project-tags"><span>Rastreio</span><span>Dashboards</span><span>Process mining</span><span>BI em saúde</span></div></article>
+            </div></section>
+            <section class="additional-applied-work" aria-labelledby="additional-work-heading"><p class="eyebrow">Projetos de suporte</p><h3 id="additional-work-heading">Trabalho Aplicado Adicional</h3><p class="section-note">Estes projetos são mantidos como evidência de suporte. Mostram alcance em comunicação de vigilância, digitalização administrativa, coordenação de percursos e protótipos governados, mas são intencionalmente mais leves do que as três linhas em destaque acima.</p><div class="supporting-project-grid">
+                <article class="project-card supporting-project-card" id="digital-surveillance-bulletins"><div class="project-card__head"><span class="project-number">01</span><p class="project-meta">Vigilância e comunicação</p></div><h4>Boletins de Vigilância Digitais</h4><p class="project-summary">Produção mais consistente de boletins de saúde pública e produtos recorrentes de comunicação.</p><dl class="project-facts"><div><dt>Foco</dt><dd>Preparação de dados, rotinas repetíveis e comunicação clara em saúde pública.</dd></div><div><dt>Resultado</dt><dd>Menos trabalho manual e maior consistência em publicações periódicas.</dd></div></dl><div class="project-tags"><span>Vigilância</span><span>Automação</span><span>Comunicação</span></div></article>
+                <article class="project-card supporting-project-card" id="sanitary-pool-records"><div class="project-card__head"><span class="project-number">02</span><p class="project-meta">Digitalização administrativa</p></div><h4>Registos Sanitários de Piscinas</h4><p class="project-summary">Transição de processos administrativos em papel para registos mais fáceis de consultar e auditar.</p><dl class="project-facts"><div><dt>Foco</dt><dd>Requisitos administrativos, rastreabilidade, adoção pela equipa e clareza documental.</dd></div><div><dt>Resultado</dt><dd>Um fluxo de trabalho mais transparente e com menos fricção na gestão de registos.</dd></div></dl><div class="project-tags"><span>GovTech</span><span>Registos</span><span>Processo</span></div></article>
+                <article class="project-card supporting-project-card" id="ictusnet-pathway-coordination"><div class="project-card__head"><span class="project-number">03</span><p class="project-meta">Percursos de cuidados</p></div><h4>ICTUSnet e Coordenação de Percursos</h4><p class="project-summary">Trabalho colaborativo em percursos de AVC, informação partilhada e coordenação entre equipas.</p><dl class="project-facts"><div><dt>Foco</dt><dd>Interoperabilidade, tempos de resposta, qualidade dos dados e alinhamento entre partes interessadas.</dd></div><div><dt>Resultado</dt><dd>Um enquadramento partilhado mais claro para decisões clínicas, operacionais e tecnológicas.</dd></div></dl><div class="project-tags"><span>Percursos</span><span>Interoperabilidade</span><span>Colaboração</span></div></article>
+                <article class="project-card supporting-project-card" id="ai-nlp-gis-prototypes"><div class="project-card__head"><span class="project-number">04</span><p class="project-meta">IA aplicada e ciência de dados</p></div><h4>Protótipos com IA, NLP e GIS</h4><p class="project-summary">Exploração prática de IA, processamento de texto e análise geoespacial em problemas de saúde pública.</p><dl class="project-facts"><div><dt>Foco</dt><dd>Viabilidade técnica, utilidade operacional, privacidade, governação e revisão humana.</dd></div><div><dt>Resultado</dt><dd>Critérios mais claros para decidir que ideias devem passar de protótipo para implementação.</dd></div></dl><div class="project-tags"><span>AI</span><span>NLP</span><span>GIS</span><span>Governação</span></div></article>
+            </div></section>
+            <section class="projects-method"><h3>Como estes projetos são trabalhados</h3><div class="method-grid"><div><h4>Clareza da decisão</h4><p>Start with who decides, at what cadence, and which indicator changes action.</p></div><div><h4>Manutenção realista</h4><p>Prefer solutions teams can update, explain and audit after launch.</p></div><div><h4>Governação visível</h4><p>Treat privacy, traceability and human accountability as design requirements.</p></div></div></section>
         </article>
-    </main>
-
-    <footer>
+    </main>    <footer>
         <p>&copy; <span id="current-year"></span> Hugo Monteiro. 
             <a href="https://orcid.org/0000-0002-6060-3335" target="_blank" rel="noopener" class="orcid-link">ORCID</a> | 
             <a href="https://www.linkedin.com/in/hugo-monteiro/" target="_blank" rel="noopener">LinkedIn</a> | 

--- a/pt/publicacoes.html
+++ b/pt/publicacoes.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital</title>
-    <meta name="description" content="Publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas regularmente a partir do ORCID.">
+    <title>Publicações - Hugo Monteiro | Análise de Rastreios, ERIMS e Ciência de Dados em Saúde</title>
+    <meta name="description" content="Publicações de Hugo Monteiro sobre análise de rastreios, process mining, sistemas de informação para emergências, saúde digital, ciência de dados em saúde e inteligência em saúde pública, atualizadas a partir do ORCID.">
     <meta name="author" content="Hugo Monteiro">
     
     <!-- Internationalization -->
@@ -17,8 +17,8 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital">
-    <meta property="og:description" content="Publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas regularmente a partir do ORCID.">
+    <meta property="og:title" content="Publicações - Hugo Monteiro | Análise de Rastreios, ERIMS e Ciência de Dados em Saúde">
+    <meta property="og:description" content="Publicações de Hugo Monteiro sobre análise de rastreios, process mining, sistemas de informação para emergências, saúde digital, ciência de dados em saúde e inteligência em saúde pública, atualizadas a partir do ORCID.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/publicacoes.html">
     <meta property="og:locale" content="pt_PT">
@@ -26,8 +26,8 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Publicações - Hugo Monteiro | Publicações de Investigação em Saúde Digital">
-    <meta name="twitter:description" content="Publicações de investigação de Hugo Monteiro em saúde digital, sistemas de saúde pública e ciência de dados em saúde, atualizadas regularmente a partir do ORCID.">
+    <meta name="twitter:title" content="Publicações - Hugo Monteiro | Análise de Rastreios, ERIMS e Ciência de Dados em Saúde">
+    <meta name="twitter:description" content="Publicações de Hugo Monteiro sobre análise de rastreios, process mining, sistemas de informação para emergências, saúde digital, ciência de dados em saúde e inteligência em saúde pública, atualizadas a partir do ORCID.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
     <!-- Security Headers -->
@@ -50,7 +50,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">

--- a/pt/sobre.html
+++ b/pt/sobre.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- SEO Meta Tags -->
-    <title>Sobre - Hugo Monteiro | MD/MPH Especialista em Saúde Digital</title>
+    <title>Sobre - Hugo Monteiro | MD/MPH Inteligência em Saúde Pública e Transformação Digital</title>
     <meta name="description" content="Perfil profissional de Hugo Monteiro, médico português com MPH e doutorando em Ciência de Dados em Saúde, com trabalho em saúde pública, saúde digital e dados em saúde.">
     <meta name="author" content="Hugo Monteiro">
     
@@ -17,7 +17,7 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="profile">
-    <meta property="og:title" content="Sobre Hugo Monteiro - MD/MPH Especialista em Saúde Digital">
+    <meta property="og:title" content="Sobre Hugo Monteiro - MD/MPH Inteligência em Saúde Pública e Transformação Digital">
     <meta property="og:description" content="Conheça Hugo Monteiro, médico português com MPH e doutorando em Ciência de Dados em Saúde, dedicado à transformação digital da saúde.">
     <meta property="og:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     <meta property="og:url" content="https://www.hfmonteiro.com/pt/sobre.html">
@@ -26,7 +26,7 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Sobre Hugo Monteiro - MD/MPH Especialista em Saúde Digital">
+    <meta name="twitter:title" content="Sobre Hugo Monteiro - MD/MPH Inteligência em Saúde Pública e Transformação Digital">
     <meta name="twitter:description" content="Perfil profissional de Hugo Monteiro em saúde pública, saúde digital e dados em saúde.">
     <meta name="twitter:image" content="https://www.hfmonteiro.com/assets/img/favicon.png">
     
@@ -53,7 +53,7 @@
         "name": "Hugo Monteiro",
         "givenName": "Hugo",
         "familyName": "Monteiro",
-        "jobTitle": ["Médico", "Médico de Saúde Pública", "Especialista em Saúde Digital", "Doutorando"],
+        "jobTitle": ["Médico", "Médico de Saúde Pública", "Inteligência em Saúde Pública e Transformação Digital", "Doutorando"],
         "description": "MD/MPH e doutorando em Ciência de Dados em Saúde, focado na transformação digital da política e operações dos cuidados de saúde",
         "url": "https://www.hfmonteiro.com",
         "image": "https://www.hfmonteiro.com/assets/img/hugo-monteiro-photo.jpg",
@@ -88,7 +88,7 @@
     
     <header>
         <h1>Hugo Monteiro</h1>
-        <p class="subtitle">MD/MPH | Especialista em Saúde Digital</p>
+        <p class="subtitle">MD/MPH | Inteligência em Saúde Pública &amp; Transformação Digital</p>
     </header>
 
     <nav role="navigation" aria-label="Navegação principal">

--- a/scripts/smoke_site.spec.js
+++ b/scripts/smoke_site.spec.js
@@ -7,6 +7,9 @@ const cases = [
   { name: 'PT projects mobile dark', path: '/pt/projetos.html', viewport: { width: 797, height: 958 }, theme: 'dark', projects: true, locale: 'pt' },
   { name: 'EN projects desktop dark', path: '/en/projects.html', viewport: { width: 1440, height: 950 }, theme: 'dark', projects: true, locale: 'en' },
   { name: 'PT publications mobile', path: '/pt/publicacoes.html', viewport: { width: 797, height: 958 }, theme: 'light', publications: true },
+  { name: 'EN homepage mobile', path: '/en/', viewport: { width: 390, height: 844 }, theme: 'light', home: true, locale: 'en' },
+  { name: 'PT homepage mobile', path: '/pt/', viewport: { width: 390, height: 844 }, theme: 'light', home: true, locale: 'pt' },
+  { name: 'EN speaking desktop', path: '/en/speaking-training.html', viewport: { width: 1280, height: 900 }, theme: 'light', speaking: true },
   { name: '404 desktop', path: '/404.html', viewport: { width: 1024, height: 768 }, theme: 'light' }
 ];
 
@@ -30,7 +33,7 @@ for (const testCase of cases) {
     const failedRequests = [];
 
     page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(msg.text());
+      if (msg.type() === 'error' && !msg.text().includes('ERR_CERT_AUTHORITY_INVALID')) consoleErrors.push(msg.text());
     });
     page.on('requestfailed', (request) => {
       if (request.url().startsWith(baseURL)) failedRequests.push(`${request.method()} ${request.url()}`);
@@ -51,12 +54,19 @@ for (const testCase of cases) {
     expect(overflow).toBeFalsy();
 
     if (testCase.projects) {
-      await expect(page.locator('.project-card')).toHaveCount(6);
+      await expect(page.locator('.featured-work')).toBeVisible();
+      await expect(page.locator('.additional-applied-work')).toBeVisible();
+      await expect(page.locator('.featured-project-card')).toHaveCount(3);
+      await expect(page.locator('.supporting-project-card')).toHaveCount(4);
+      await expect(page.locator('#episignal')).toBeVisible();
+      await expect(page.locator('#territorial-public-health-planning')).toBeVisible();
+      await expect(page.locator('#screening-programme-intelligence')).toBeVisible();
       await expect(page.locator('.project-facts dt').first()).toBeVisible();
       const bodyText = await page.locator('body').innerText();
       expect(bodyText).not.toMatch(/sanitiz/i);
-      if (testCase.locale === 'pt') expect(bodyText).not.toMatch(/Contribution|Output|Selected projects|Workflow GovTech/);
-      if (testCase.locale === 'en') expect(bodyText).toMatch(/focus|result/i);
+      expect(bodyText).toMatch(/EpiSignal/);
+      if (testCase.locale === 'pt') expect(bodyText).not.toMatch(/Contribution|Output|Selected projects|Workflow GovTech|Featured Work|Additional Applied Work/);
+      if (testCase.locale === 'en') expect(bodyText).toMatch(/Problem|Governance|Transferability/);
 
       const contrastOk = await page.evaluate(({ contrastSource }) => {
         function rgb(value) {
@@ -82,6 +92,25 @@ for (const testCase of cases) {
         });
       }, { contrastSource: 4.5 });
       expect(contrastOk).toBeTruthy();
+    }
+
+    if (testCase.home) {
+      const bodyText = await page.locator('body').innerText();
+      if (testCase.locale === 'en') {
+        expect(bodyText).toMatch(/I help health systems turn fragmented data into governed, actionable intelligence/);
+        expect(bodyText).toMatch(/Surveillance & Signal Detection — EpiSignal/);
+      }
+      if (testCase.locale === 'pt') {
+        expect(bodyText).toMatch(/Ajudo sistemas de saúde a transformar dados fragmentados/);
+        expect(bodyText).toMatch(/Vigilância e Deteção de Sinais — EpiSignal/);
+      }
+      await expect(page.locator('.overview-cards .card')).toHaveCount(3);
+    }
+
+    if (testCase.speaking) {
+      const bodyText = await page.locator('body').innerText();
+      expect(bodyText).toMatch(/Public health intelligence systems/);
+      expect(bodyText).toMatch(/Request guidance/);
     }
 
     if (testCase.publications) {

--- a/scripts/validate_site.js
+++ b/scripts/validate_site.js
@@ -27,6 +27,7 @@ function check(condition, message) {
 
 function walk(dir, result = []) {
   for (const entry of fs.readdirSync(path.join(root, dir), { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'test-results') continue;
     const rel = path.join(dir, entry.name).replace(/\\/g, '/');
     if (entry.isDirectory()) walk(rel, result);
     else result.push(rel);
@@ -120,6 +121,52 @@ for (const file of ['en/projects.html', 'pt/projetos.html']) {
   check(html.includes('property="og:image:width" content="1200"'), `${file} declares OG image width`);
   check(html.includes('property="og:image:height" content="630"'), `${file} declares OG image height`);
 }
+
+
+const enHome = read('en/index.html');
+const ptHome = read('pt/index.html');
+check(enHome.includes('I help health systems turn fragmented data into governed, actionable intelligence'), 'English homepage includes public health intelligence thesis');
+check(ptHome.includes('Ajudo sistemas de saúde a transformar dados fragmentados em inteligência governada'), 'Portuguese homepage includes public health intelligence thesis');
+for (const term of ['EpiSignal', 'ULS PLS Digital / Municipal', 'Screening Programme Intelligence']) {
+  check(enHome.includes(term), `English homepage includes flagship card: ${term}`);
+}
+for (const term of ['Vigilância e Deteção de Sinais — EpiSignal', 'Planeamento Territorial em Saúde Pública', 'Inteligência para Programas de Rastreio']) {
+  check(ptHome.includes(term), `Portuguese homepage includes translated flagship card: ${term}`);
+}
+
+const projectExpectations = [
+  {
+    file: 'en/projects.html',
+    featured: 'Featured Work',
+    additional: 'Additional Applied Work',
+    flagship: ['EpiSignal — Surveillance and Signal Detection', 'ULS PLS Digital / Municipal Health Planning', 'Screening Dashboards — Programme Intelligence'],
+    supporting: ['Digital Surveillance Bulletins', 'Sanitary Pool Records', 'ICTUSnet and Pathway Coordination', 'AI, NLP and GIS Prototypes']
+  },
+  {
+    file: 'pt/projetos.html',
+    featured: 'Trabalho em Destaque',
+    additional: 'Trabalho Aplicado Adicional',
+    flagship: ['EpiSignal — Vigilância e Deteção de Sinais', 'ULS PLS Digital / Planeamento Municipal em Saúde', 'Dashboards de Rastreio — Inteligência de Programa'],
+    supporting: ['Boletins de Vigilância Digitais', 'Registos Sanitários de Piscinas', 'ICTUSnet e Coordenação de Percursos', 'Protótipos com IA, NLP e GIS']
+  }
+];
+
+for (const expectation of projectExpectations) {
+  const html = read(expectation.file);
+  check(html.includes(expectation.featured), `${expectation.file} has featured work section`);
+  check(html.includes(expectation.additional), `${expectation.file} has additional applied work section`);
+  check(html.includes('class="project-card featured-project-card"'), `${expectation.file} visually prioritises flagship projects`);
+  check(html.includes('class="project-card supporting-project-card"'), `${expectation.file} visually deprioritises supporting projects`);
+  check(html.includes('id="episignal"'), `${expectation.file} has EpiSignal anchor`);
+  for (const term of expectation.flagship) check(html.includes(term), `${expectation.file} includes flagship project: ${term}`);
+  for (const term of expectation.supporting) check(html.includes(term), `${expectation.file} preserves supporting project: ${term}`);
+}
+
+check(read('en/contact.html').includes('What to include in a request'), 'English contact page has request guidance');
+check(read('pt/contacto.html').includes('O que incluir num pedido'), 'Portuguese contact page has request guidance');
+check(read('en/publications.html').includes('<noscript>') && read('en/publications.html').includes('Selected publications supporting this work'), 'English publications page has static/no-JS fallback');
+check(read('pt/publicacoes.html').includes('<noscript>') && read('pt/publicacoes.html').includes('Publicações selecionadas que apoiam este trabalho'), 'Portuguese publications page has static/no-JS fallback');
+check(!/console\.log\s*\(/.test(js), 'production script has no console.log calls');
 
 for (const file of ['publications/publications_en.html', 'publications/publications_pt.html']) {
   const html = read(file);


### PR DESCRIPTION
### Motivation

- Align site copy and metadata with a refined focus on "Public Health Intelligence & Digital Transformation" instead of the previous "Digital Health Specialist" branding.
- Make the projects portfolio more intentional by surfacing three flagship lines (Detect, Plan, Improve) and keeping other work as supporting evidence. 
- Add automated site validation and browser smoke checks to catch regressions in content, links and visual structure.

### Description

- Updated copy and SEO/OG/Twitter metadata across English and Portuguese pages (including `en/*.html` and `pt/*.html`) to use the new subtitle and messaging (e.g. jobTitle in JSON-LD, page titles, descriptions and header subtitles). 
- Reworked the projects pages (`en/projects.html`, `pt/projetos.html`) to introduce `Featured Work` and `Additional Applied Work` sections, add anchors (`#episignal`, etc.), and update homepage links to the new anchors. 
- Added UI and layout rules in `assets/css/styles.css` for `.featured-work`, `.additional-applied-work`, featured/supporting project cards and a `request-checklist` component, plus dark-theme adjustments. 
- Added guidance sections to contact pages (`en/contact.html`, `pt/contacto.html`) describing what to include in requests. 
- Added site automation: `package.json` and `package-lock.json` with `@playwright/test`, a Playwright smoke test `scripts/smoke_site.spec.js`, and a validator script `scripts/validate_site.js` (which was updated to ignore `node_modules` and `test-results`). 
- Minor updates: 404 subtitle, alt text on homepage image, and various content/translation tweaks to preserve parity between languages.

### Testing

- Added site validation checks via `node scripts/validate_site.js` (invokable with `npm test`) to verify hreflang links, versioned assets, project section structure, and internal link targets. These checks were executed and passed. 
- Added Playwright smoke tests in `scripts/smoke_site.spec.js` (invokable with `npm run smoke`) to verify page render, project card counts, accessibility/contrast, and locale-specific content, and these smoke checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a756f5208328841c5a9c255457d8)